### PR TITLE
DB の構成を変えて複数サーバーで動かせるようにする

### DIFF
--- a/wathematica_discord_bot/Cogs/AdminTools/reload.py
+++ b/wathematica_discord_bot/Cogs/AdminTools/reload.py
@@ -12,11 +12,11 @@ class Reload(commands.Cog):
     @slash_command(
         name="reload",
         description="[技術部専用] 指定されたCogをリロードします",
-        guild_ids=[config.guild_id],
+        # guild_ids=[config.guild_id],
     )
     # see https://docs.pycord.dev/en/master/ext/commands/api.html#checks to
     # know how to use 'checker' decorators like 'has_role'
-    @commands.has_role(config.engineer_role_id)
+    # @commands.has_role(config.engineer_role_id)
     async def reload(
         self,
         ctx: discord.ApplicationContext,

--- a/wathematica_discord_bot/Cogs/AdminTools/reload.py
+++ b/wathematica_discord_bot/Cogs/AdminTools/reload.py
@@ -1,9 +1,8 @@
-import config
 import discord
 from discord import ExtensionNotFound, ExtensionNotLoaded, Option
 from discord.commands import slash_command
 from discord.ext import commands
-
+from checks import has_engineer_role_only
 
 class Reload(commands.Cog):
     def __init__(self, bot: discord.Bot):
@@ -12,11 +11,11 @@ class Reload(commands.Cog):
     @slash_command(
         name="reload",
         description="[技術部専用] 指定されたCogをリロードします",
-        # guild_ids=[config.guild_id],
+        default_member_permissions=discord.Permissions(administrator=True),
     )
     # see https://docs.pycord.dev/en/master/ext/commands/api.html#checks to
     # know how to use 'checker' decorators like 'has_role'
-    # @commands.has_role(config.engineer_role_id)
+    @has_engineer_role_only()
     async def reload(
         self,
         ctx: discord.ApplicationContext,

--- a/wathematica_discord_bot/Cogs/AdminTools/reload.py
+++ b/wathematica_discord_bot/Cogs/AdminTools/reload.py
@@ -4,6 +4,7 @@ from discord.commands import slash_command
 from discord.ext import commands
 from checks import has_engineer_role_only
 
+
 class Reload(commands.Cog):
     def __init__(self, bot: discord.Bot):
         self.bot = bot

--- a/wathematica_discord_bot/Cogs/GuildControllers/auto_setup.py
+++ b/wathematica_discord_bot/Cogs/GuildControllers/auto_setup.py
@@ -1,0 +1,105 @@
+import discord
+from discord.ext import commands
+from sqlalchemy import select
+
+from database import async_session
+from model import Guild, Category, SeminarState
+
+from view.settings_view import get_settings_embed
+
+
+class AutoSetup(commands.Cog):
+    def __init__(self, bot: discord.Bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        for guild in self.bot.guilds:
+            await self._run_auto_setup(guild)
+
+    @commands.Cog.listener()
+    async def on_guild_join(self, guild: discord.Guild):
+        await self._run_auto_setup(guild)
+
+    async def _run_auto_setup(self, guild: discord.Guild):
+        system_channel_id = None  # 通知を送るためのチャンネルIDを覚えておく変数
+
+        async with async_session() as session:
+            async with session.begin():
+                stmt = select(Guild).where(Guild.guild_id == guild.id)
+                existing_guild = (await session.execute(stmt)).scalar_one_or_none()
+
+                if existing_guild:
+                    return
+
+                print(f"[{guild.name}] Auto-configuring...")
+                new_guild = Guild(guild_id=guild.id, name=guild.name)
+
+                # --- チャンネルの検出 ---
+                role_channels = [c for c in guild.text_channels if "権限設定" in c.name]
+                if len(role_channels) == 1:
+                    new_guild.role_setting_channel_id = role_channels[0].id
+
+                system_channels = [
+                    c for c in guild.text_channels if "system" in c.name.lower()
+                ]
+                if len(system_channels) == 1:
+                    new_guild.system_channel_id = system_channels[0].id
+                    # ▼ ここで system チャンネルの ID を記憶しておく
+                    system_channel_id = system_channels[0].id
+
+                # --- ロールの検出 ---
+                engineer_roles = [r for r in guild.roles if "技術部" in r.name]
+                if len(engineer_roles) == 1:
+                    new_guild.engineer_role_id = engineer_roles[0].id
+
+                # --- 絵文字の検出 ---
+                interesting_emojis = [
+                    e for e in guild.emojis if e.name == "interesting"
+                ]
+                if len(interesting_emojis) == 1:
+                    new_guild.interesting_emoji_id = interesting_emojis[0].id
+
+                session.add(new_guild)
+
+                # --- カテゴリーの検出と登録 ---
+                for cat in guild.categories:
+                    state = None
+                    if "ゼミ" in cat.name and "仮立て" in cat.name:
+                        state = SeminarState.PENDING
+                    elif "ゼミ" in cat.name and "本運用" in cat.name:
+                        state = SeminarState.ONGOING
+                    elif "ゼミ" in cat.name and "休止中" in cat.name:
+                        state = SeminarState.PAUSED
+                    elif "ゼミ" in cat.name and "終了" in cat.name:
+                        state = SeminarState.FINISHED
+
+                    if state:
+                        new_cat = Category(
+                            category_id=cat.id,
+                            name=cat.name,
+                            guild_id=guild.id,
+                            state=state,
+                            category_type="regular",
+                        )
+                        session.add(new_cat)
+
+        # ---------------------------------------------------------
+        # DBへの保存（コミット）が完全に終わった後の処理
+        # ---------------------------------------------------------
+        if system_channel_id:
+            system_channel = guild.get_channel(system_channel_id)
+            if isinstance(system_channel, discord.TextChannel):
+                # DBから最新の状態を読み込んで、あのダッシュボードと同じEmbedを作成！
+                embed = await get_settings_embed(guild.id, guild.name, self.bot)
+
+                # 通知用にタイトルや説明文だけ少しアレンジする（上書き）
+                embed.title = "✨ Botの初期セットアップが完了しました"
+                embed.description = "サーバーの構成を自動検出し、以下の通り設定しました。\n手動で変更が必要な場合は `/setting` コマンドを使用してください。"
+                embed.color = discord.Colour.brand_green()
+
+                await system_channel.send(embed=embed)
+
+
+def setup(bot: discord.Bot):
+    bot.add_cog(AutoSetup(bot))

--- a/wathematica_discord_bot/Cogs/GuildControllers/initialize.py
+++ b/wathematica_discord_bot/Cogs/GuildControllers/initialize.py
@@ -8,7 +8,7 @@ from model import Guild, Category, SeminarState
 from view.settings_view import get_settings_embed
 
 
-class AutoSetup(commands.Cog):
+class Initialize(commands.Cog):
     def __init__(self, bot: discord.Bot):
         self.bot = bot
 
@@ -102,4 +102,4 @@ class AutoSetup(commands.Cog):
 
 
 def setup(bot: discord.Bot):
-    bot.add_cog(AutoSetup(bot))
+    bot.add_cog(Initialize(bot))

--- a/wathematica_discord_bot/Cogs/GuildControllers/settings.py
+++ b/wathematica_discord_bot/Cogs/GuildControllers/settings.py
@@ -10,7 +10,7 @@ class Settings(commands.Cog):
         self.bot = bot
 
     @slash_command(
-        name="setting", 
+        name="setting",
         description="サーバー設定ダッシュボードを開きます",
         default_member_permissions=discord.Permissions(administrator=True),
     )

--- a/wathematica_discord_bot/Cogs/GuildControllers/settings.py
+++ b/wathematica_discord_bot/Cogs/GuildControllers/settings.py
@@ -9,7 +9,11 @@ class Settings(commands.Cog):
     def __init__(self, bot: discord.Bot):
         self.bot = bot
 
-    @slash_command(name="setting", description="サーバー設定ダッシュボードを開きます")
+    @slash_command(
+        name="setting", 
+        description="サーバー設定ダッシュボードを開きます",
+        default_member_permissions=discord.Permissions(administrator=True),
+    )
     async def guild_setting(self, ctx: discord.ApplicationContext):
         await ctx.defer()
 

--- a/wathematica_discord_bot/Cogs/GuildControllers/settings.py
+++ b/wathematica_discord_bot/Cogs/GuildControllers/settings.py
@@ -1,0 +1,27 @@
+import discord
+from discord.ext import commands
+from discord.commands import slash_command
+
+from view.settings_view import get_settings_embed, SettingsDashboardView
+
+
+class Settings(commands.Cog):
+    def __init__(self, bot: discord.Bot):
+        self.bot = bot
+
+    @slash_command(name="setting", description="サーバー設定ダッシュボードを開きます")
+    async def guild_setting(self, ctx: discord.ApplicationContext):
+        await ctx.defer()
+
+        # 1. UIファイルから最新の Embed を生成してもらう
+        embed = await get_settings_embed(ctx.guild.id, ctx.guild.name, self.bot)
+
+        # 2. UIファイルからボタン群 (View) を生成する
+        view = SettingsDashboardView(self.bot)
+
+        # 3. メッセージを送信！
+        await ctx.respond(embed=embed, view=view)
+
+
+def setup(bot: discord.Bot):
+    bot.add_cog(Settings(bot))

--- a/wathematica_discord_bot/Cogs/SeminarControllers/begin.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/begin.py
@@ -4,11 +4,7 @@ from checks import specific_states_only, textchannel_only, registered_server_onl
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import (
-    InvalidCategoryException,
-    InvalidChannelTypeException,
-    ConfigurationNotCompleteException,
-)
+from exceptions import *
 from model import Seminar, SeminarState, Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
@@ -132,6 +128,22 @@ class Begin(commands.Cog):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
                 description="《ゼミ(仮立て)》にあるテキストチャンネルでのみ実行可能です。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
+        if isinstance(error, CategoryNotRegisteredException):
+            embed = discord.Embed(
+                title=":x: チャンネル作成失敗",
+                description="《ゼミ(本運用)》カテゴリーが登録されていません。管理者に `/setting` で設定を依頼してください。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
+        if isinstance(error, CategoryUnavailableException):
+            embed = discord.Embed(
+                title=":x: チャンネル作成失敗",
+                description="《ゼミ(本運用)》カテゴリーに空きがありません。管理者にカテゴリー作成・設定を依頼してください。",
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)

--- a/wathematica_discord_bot/Cogs/SeminarControllers/begin.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/begin.py
@@ -1,7 +1,7 @@
 import config
 import utils
 import discord
-from checks import specific_categories_only, textchannel_only
+from checks import specific_states_only, textchannel_only
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
@@ -16,12 +16,12 @@ class Begin(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
-    # @specific_categories_only(
-    #     category_ids=[
-    #         config.category_info["pending_seminars"]["id"],
-    #         config.category_info["paused_seminars"]["id"],
-    #     ]
-    # )
+    @specific_states_only(
+        states=[
+            SeminarState.PENDING,
+            SeminarState.PAUSED,
+        ]
+    )
     @textchannel_only()
     @slash_command(
         name="begin",

--- a/wathematica_discord_bot/Cogs/SeminarControllers/begin.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/begin.py
@@ -4,8 +4,12 @@ from checks import specific_states_only, textchannel_only, registered_server_onl
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
-from model import Seminar, SeminarState, Category, Guild
+from exceptions import (
+    InvalidCategoryException,
+    InvalidChannelTypeException,
+    ConfigurationNotCompleteException,
+)
+from model import Seminar, SeminarState, Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -25,7 +29,7 @@ class Begin(commands.Cog):
     @textchannel_only()
     @slash_command(
         name="begin",
-        description='ゼミを《ゼミ(本運用)》に移動させます',
+        description="ゼミを《ゼミ(本運用)》に移動させます",
     )
     async def begin(self, ctx: discord.ApplicationContext):
         # [ give additional information to type checker
@@ -33,19 +37,6 @@ class Begin(commands.Cog):
         assert isinstance(ctx.guild, discord.Guild)
         # ]
 
-        async with async_session() as session:
-            guild_record = (
-                await session.execute(
-                    select(Guild).where(
-                        Guild.guild_id == ctx.guild_id
-                    )
-                )
-            ).scalar_one_or_none()
-
-        # ongoing_seminar_category = ctx.guild.get_channel(
-        #     config.category_info["ongoing_seminars"]["id"]
-        # )
-        # 
         ongoing_seminar_category = await utils.get_category(ctx, SeminarState.ONGOING)
         if not isinstance(ongoing_seminar_category, discord.CategoryChannel):
             embed = discord.Embed(
@@ -55,7 +46,6 @@ class Begin(commands.Cog):
             )
             await ctx.respond(embed=embed)
             return
-        
 
         # move the channel to the ongoing_seminar category
         await ctx.channel.edit(
@@ -93,7 +83,9 @@ class Begin(commands.Cog):
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).join(Category).where(
+                            select(Seminar)
+                            .join(Category)
+                            .where(
                                 Seminar.channel_id == ctx.channel.id,
                                 Category.guild_id == ctx.guild_id,
                             )
@@ -111,7 +103,7 @@ class Begin(commands.Cog):
 
         embed = discord.Embed(
             title="<:white_check_mark:960095096563466250> チャンネル移動成功",
-            description=f'チャンネルを《{ongoing_seminar_category.name}》へ移動しました。',
+            description=f"チャンネルを《{ongoing_seminar_category.name}》へ移動しました。",
             color=discord.Colour.brand_green(),
         )
         await ctx.respond(embed=embed)
@@ -139,7 +131,7 @@ class Begin(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description='《ゼミ(仮立て)》にあるテキストチャンネルでのみ実行可能です。',
+                description="《ゼミ(仮立て)》にあるテキストチャンネルでのみ実行可能です。",
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)

--- a/wathematica_discord_bot/Cogs/SeminarControllers/begin.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/begin.py
@@ -1,11 +1,11 @@
 import config
 import utils
 import discord
-from checks import specific_states_only, textchannel_only
+from checks import specific_states_only, textchannel_only, registered_server_only
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException
+from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
 from model import Seminar, SeminarState, Category, Guild
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
@@ -16,6 +16,7 @@ class Begin(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
+    @registered_server_only()
     @specific_states_only(
         states=[
             SeminarState.PENDING,
@@ -121,6 +122,14 @@ class Begin(commands.Cog):
     async def begin_error(
         self, ctx: discord.ApplicationContext, error: commands.CheckFailure
     ):
+        if isinstance(error, ConfigurationNotCompleteException):
+            embed = discord.Embed(
+                title="<:x:960095353577807883> サーバー設定ができていません",
+                description="管理者に `/setting` で設定を依頼してください。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
         if isinstance(error, InvalidChannelTypeException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",

--- a/wathematica_discord_bot/Cogs/SeminarControllers/begin.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/begin.py
@@ -1,11 +1,12 @@
 import config
+import utils
 import discord
 from checks import specific_categories_only, textchannel_only
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
 from exceptions import InvalidCategoryException, InvalidChannelTypeException
-from model import Seminar, SeminarState
+from model import Seminar, SeminarState, Category, Guild
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -15,17 +16,17 @@ class Begin(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
-    @specific_categories_only(
-        category_ids=[
-            config.category_info["pending_seminars"]["id"],
-            config.category_info["paused_seminars"]["id"],
-        ]
-    )
+    # @specific_categories_only(
+    #     category_ids=[
+    #         config.category_info["pending_seminars"]["id"],
+    #         config.category_info["paused_seminars"]["id"],
+    #     ]
+    # )
     @textchannel_only()
     @slash_command(
         name="begin",
-        description=f'ゼミを{config.category_info["ongoing_seminars"]["name"]}に移動させます',
-        guild_ids=[config.guild_id],
+        description=f'ゼミをゼミ(本運用)に移動させます',
+        # guild_ids=[config.guild_id],
     )
     async def begin(self, ctx: discord.ApplicationContext):
         # [ give additional information to type checker
@@ -33,9 +34,20 @@ class Begin(commands.Cog):
         assert isinstance(ctx.guild, discord.Guild)
         # ]
 
-        ongoing_seminar_category = ctx.guild.get_channel(
-            config.category_info["ongoing_seminars"]["id"]
-        )
+        async with async_session() as session:
+            guild_record = (
+                await session.execute(
+                    select(Guild).where(
+                        Guild.guild_id == ctx.guild_id
+                    )
+                )
+            ).scalar_one_or_none()
+
+        # ongoing_seminar_category = ctx.guild.get_channel(
+        #     config.category_info["ongoing_seminars"]["id"]
+        # )
+        # 
+        ongoing_seminar_category = await utils.get_category(ctx, SeminarState.ONGOING)
         if not isinstance(ongoing_seminar_category, discord.CategoryChannel):
             embed = discord.Embed(
                 title="<:x:960095353577807883> システムエラー",
@@ -44,46 +56,52 @@ class Begin(commands.Cog):
             )
             await ctx.respond(embed=embed)
             return
+        
 
         # move the channel to the ongoing_seminar category
-
-        number_of_channels = await get_nuber_of_channel(
-            ctx, config.category_info["ongoing_seminars"]["name"]
+        await ctx.channel.edit(
+            category=ongoing_seminar_category,
+            reason=f"Requested by {ctx.author.name}",
         )
-        if number_of_channels < MAX_CHANNELS:
-            await ctx.channel.edit(
-                category=ongoing_seminar_category,
-                reason=f"Requested by {ctx.author.name}",
-            )
-        else:
-            ongoing_seminar_category = ctx.guild.get_channel(
-                config.category_info["ongoing_seminars2"]["id"]
-            )
-            if not isinstance(ongoing_seminar_category, discord.CategoryChannel):
-                embed = discord.Embed(
-                    title="<:x:960095353577807883> システムエラー",
-                    description="管理者向けメッセージ: `ongoing_seminars2` カテゴリが見つかりませんでした。",
-                    color=discord.Colour.red(),
-                )
-                await ctx.respond(embed=embed)
-                return
-            await ctx.channel.edit(
-                category=ongoing_seminar_category,
-                reason=f"Requested by {ctx.author.name}",
-            )
+
+        # number_of_channels = await get_nuber_of_channel(
+        #     ctx, config.category_info["ongoing_seminars"]["name"]
+        # )
+        # if number_of_channels < MAX_CHANNELS:
+        #     await ctx.channel.edit(
+        #         category=ongoing_seminar_category,
+        #         reason=f"Requested by {ctx.author.name}",
+        #     )
+        # else:
+        #     ongoing_seminar_category = ctx.guild.get_channel(
+        #         config.category_info["ongoing_seminars2"]["id"]
+        #     )
+        #     if not isinstance(ongoing_seminar_category, discord.CategoryChannel):
+        #         embed = discord.Embed(
+        #             title="<:x:960095353577807883> システムエラー",
+        #             description="管理者向けメッセージ: `ongoing_seminars2` カテゴリが見つかりませんでした。",
+        #             color=discord.Colour.red(),
+        #         )
+        #         await ctx.respond(embed=embed)
+        #         return
+        #     await ctx.channel.edit(
+        #         category=ongoing_seminar_category,
+        #         reason=f"Requested by {ctx.author.name}",
+        #     )
 
         async with async_session() as session:
             async with session.begin():
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).where(
+                            select(Seminar).join(Category).where(
                                 Seminar.channel_id == ctx.channel.id,
-                                Seminar.server_id == ctx.guild_id,
+                                Category.guild_id == ctx.guild_id,
                             )
                         )
                     ).scalar_one()
-                    this_seminar.seminar_state = SeminarState.ONGOING
+                    # this_seminar.seminar_state = SeminarState.ONGOING
+                    this_seminar.category_id = ongoing_seminar_category.id
                 except NoResultFound:
                     embed = discord.Embed(
                         title="<:warning:960146803846684692> データベース編集失敗",
@@ -94,7 +112,7 @@ class Begin(commands.Cog):
 
         embed = discord.Embed(
             title="<:white_check_mark:960095096563466250> チャンネル移動成功",
-            description=f'チャンネルを{config.category_info["ongoing_seminars"]["name"]}へ移動しました。',
+            description=f'チャンネルを《{ongoing_seminar_category.name}》へ移動しました。',
             color=discord.Colour.brand_green(),
         )
         await ctx.respond(embed=embed)
@@ -114,7 +132,7 @@ class Begin(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description=f'{config.category_info["pending_seminars"]["name"]}または{config.category_info["paused_seminars"]["name"]}にあるテキストチャンネルでのみ実行可能です。',
+                description='《ゼミ(仮立て)》にあるテキストチャンネルでのみ実行可能です。',
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)
@@ -127,9 +145,9 @@ def setup(bot: discord.Bot):
     bot.add_cog(Begin(bot))
 
 
-MAX_CHANNELS = 50
+# MAX_CHANNELS = 50
 
 
-async def get_nuber_of_channel(ctx: discord.ApplicationContext, category_name: str):
-    category = discord.utils.get(ctx.guild.categories, name=category_name)
-    return len(category.channels)
+# async def get_nuber_of_channel(ctx: discord.ApplicationContext, category_name: str):
+#     category = discord.utils.get(ctx.guild.categories, name=category_name)
+#     return len(category.channels)

--- a/wathematica_discord_bot/Cogs/SeminarControllers/begin.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/begin.py
@@ -1,4 +1,3 @@
-import config
 import utils
 import discord
 from checks import specific_states_only, textchannel_only, registered_server_only
@@ -26,8 +25,7 @@ class Begin(commands.Cog):
     @textchannel_only()
     @slash_command(
         name="begin",
-        description=f'ゼミをゼミ(本運用)に移動させます',
-        # guild_ids=[config.guild_id],
+        description='ゼミを《ゼミ(本運用)》に移動させます',
     )
     async def begin(self, ctx: discord.ApplicationContext):
         # [ give additional information to type checker

--- a/wathematica_discord_bot/Cogs/SeminarControllers/chleader.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/chleader.py
@@ -8,7 +8,7 @@ from discord import Option
 from discord.commands import slash_command
 from discord.ext import commands
 from exceptions import InvalidCategoryException, InvalidChannelTypeException
-from model import Seminar
+from model import Seminar, Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -18,18 +18,18 @@ class ChangeLeader(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
-    @specific_categories_only(
-        category_ids=[
-            config.category_info["pending_seminars"]["id"],
-            config.category_info["ongoing_seminars"]["id"],
-            config.category_info["ongoing_seminars2"]["id"],
-        ]
-    )
+    # @specific_categories_only(
+    #     category_ids=[
+    #         config.category_info["pending_seminars"]["id"],
+    #         config.category_info["ongoing_seminars"]["id"],
+    #         config.category_info["ongoing_seminars2"]["id"],
+    #     ]
+    # )
     @textchannel_only()
     @slash_command(
         name="chleader",
         description="このゼミのゼミ長を変更します",
-        guild_ids=[config.guild_id],
+        # guild_ids=[config.guild_id],
     )
     async def chleader(
         self,
@@ -82,9 +82,9 @@ class ChangeLeader(commands.Cog):
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).where(
+                            select(Seminar).join(Category).where(
                                 Seminar.channel_id == ctx.channel.id,
-                                Seminar.server_id == ctx.guild_id,
+                                Category.guild_id == ctx.guild_id,
                             )
                         )
                     ).scalar_one()
@@ -136,7 +136,7 @@ class ChangeLeader(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description=f'{config.category_info["pending_seminars"]["name"]}または{config.category_info["ongoing_seminars"]["name"]}にあるテキストチャンネルでのみ実行可能です。',
+                description='《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。',
                 color=discord.Colour.red(),
             )
             await ctx.respond(

--- a/wathematica_discord_bot/Cogs/SeminarControllers/chleader.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/chleader.py
@@ -2,12 +2,12 @@ import textwrap
 
 import config
 import discord
-from checks import specific_states_only, textchannel_only
+from checks import specific_states_only, textchannel_only, registered_server_only
 from database import async_session
 from discord import Option
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException
+from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
 from model import Seminar, SeminarState,Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
@@ -18,13 +18,7 @@ class ChangeLeader(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
-    # @specific_categories_only(
-    #     category_ids=[
-    #         config.category_info["pending_seminars"]["id"],
-    #         config.category_info["ongoing_seminars"]["id"],
-    #         config.category_info["ongoing_seminars2"]["id"],
-    #     ]
-    # )
+    @registered_server_only()
     @specific_states_only(states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED])
     @textchannel_only()
     @slash_command(
@@ -126,6 +120,14 @@ class ChangeLeader(commands.Cog):
     async def chleader_error(
         self, ctx: discord.ApplicationContext, error: commands.CheckFailure
     ):
+        if isinstance(error, ConfigurationNotCompleteException):
+            embed = discord.Embed(
+                title="<:x:960095353577807883> サーバー設定ができていません",
+                description="管理者に `/setting` で設定を依頼してください。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
         if isinstance(error, InvalidChannelTypeException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",

--- a/wathematica_discord_bot/Cogs/SeminarControllers/chleader.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/chleader.py
@@ -2,13 +2,13 @@ import textwrap
 
 import config
 import discord
-from checks import specific_categories_only, textchannel_only
+from checks import specific_states_only, textchannel_only
 from database import async_session
 from discord import Option
 from discord.commands import slash_command
 from discord.ext import commands
 from exceptions import InvalidCategoryException, InvalidChannelTypeException
-from model import Seminar, Category
+from model import Seminar, SeminarState,Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -25,6 +25,7 @@ class ChangeLeader(commands.Cog):
     #         config.category_info["ongoing_seminars2"]["id"],
     #     ]
     # )
+    @specific_states_only(states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED])
     @textchannel_only()
     @slash_command(
         name="chleader",

--- a/wathematica_discord_bot/Cogs/SeminarControllers/chleader.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/chleader.py
@@ -7,8 +7,12 @@ from database import async_session
 from discord import Option
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
-from model import Seminar, SeminarState,Category
+from exceptions import (
+    InvalidCategoryException,
+    InvalidChannelTypeException,
+    ConfigurationNotCompleteException,
+)
+from model import Seminar, SeminarState, Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -19,7 +23,9 @@ class ChangeLeader(commands.Cog):
 
     @commands.guild_only()
     @registered_server_only()
-    @specific_states_only(states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED])
+    @specific_states_only(
+        states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED]
+    )
     @textchannel_only()
     @slash_command(
         name="chleader",
@@ -76,7 +82,9 @@ class ChangeLeader(commands.Cog):
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).join(Category).where(
+                            select(Seminar)
+                            .join(Category)
+                            .where(
                                 Seminar.channel_id == ctx.channel.id,
                                 Category.guild_id == ctx.guild_id,
                             )
@@ -138,7 +146,7 @@ class ChangeLeader(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description='《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。',
+                description="《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。",
                 color=discord.Colour.red(),
             )
             await ctx.respond(

--- a/wathematica_discord_bot/Cogs/SeminarControllers/chleader.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/chleader.py
@@ -24,7 +24,6 @@ class ChangeLeader(commands.Cog):
     @slash_command(
         name="chleader",
         description="このゼミのゼミ長を変更します",
-        # guild_ids=[config.guild_id],
     )
     async def chleader(
         self,

--- a/wathematica_discord_bot/Cogs/SeminarControllers/delete.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/delete.py
@@ -17,7 +17,6 @@ class Delete(commands.Cog):
     @slash_command(
         name="delete",
         description="名前が seminar_name のゼミを削除します。",
-        # guild_ids=[config.guild_id],
     )
     async def delete(
         self,

--- a/wathematica_discord_bot/Cogs/SeminarControllers/delete.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/delete.py
@@ -4,7 +4,7 @@ from database import async_session
 from discord import Option
 from discord.commands import slash_command
 from discord.ext import commands
-from model import Seminar
+from model import Seminar, Category, Guild
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -17,7 +17,7 @@ class Delete(commands.Cog):
     @slash_command(
         name="delete",
         description="名前が seminar_name のゼミを削除します。",
-        guild_ids=[config.guild_id],
+        # guild_ids=[config.guild_id],
     )
     async def delete(
         self,
@@ -38,6 +38,15 @@ class Delete(commands.Cog):
         assert isinstance(ctx.author, discord.Member)
         # ]
 
+        async with async_session() as session:
+            guild_record = (
+                await session.execute(
+                    select(Guild).where(
+                        Guild.guild_id == ctx.guild_id
+                    )
+                )
+            ).scalar_one_or_none()
+
         # this command must be executed by the leader of the seminar
         # or by someone who has the manage_channels permission
         async with async_session() as session:
@@ -45,9 +54,9 @@ class Delete(commands.Cog):
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).where(
+                            select(Seminar).join(Category).where(
                                 Seminar.name == seminar_name,
-                                Seminar.server_id == ctx.guild_id,
+                                Category.guild_id == ctx.guild_id,
                             )
                         )
                     ).scalar_one()
@@ -129,8 +138,11 @@ class Delete(commands.Cog):
             await ctx.respond(embed=embed)
 
         # delete the message in role_settings channel
+        # role_setting_channel = ctx.guild.get_channel(
+        #     config.channel_info["role_settings"]["id"]
+        # )
         role_setting_channel = ctx.guild.get_channel(
-            config.channel_info["role_settings"]["id"]
+            guild_record.role_setting_channel_id
         )
         if not isinstance(role_setting_channel, discord.TextChannel):
             embed = discord.Embed(

--- a/wathematica_discord_bot/Cogs/SeminarControllers/delete.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/delete.py
@@ -40,9 +40,7 @@ class Delete(commands.Cog):
         async with async_session() as session:
             guild_record = (
                 await session.execute(
-                    select(Guild).where(
-                        Guild.guild_id == ctx.guild_id
-                    )
+                    select(Guild).where(Guild.guild_id == ctx.guild_id)
                 )
             ).scalar_one_or_none()
 
@@ -53,7 +51,9 @@ class Delete(commands.Cog):
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).join(Category).where(
+                            select(Seminar)
+                            .join(Category)
+                            .where(
                                 Seminar.name == seminar_name,
                                 Category.guild_id == ctx.guild_id,
                             )

--- a/wathematica_discord_bot/Cogs/SeminarControllers/end.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/end.py
@@ -7,7 +7,8 @@ from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
 from exceptions import InvalidCategoryException, InvalidChannelTypeException
-from model import Seminar, SeminarState
+from model import Seminar, SeminarState, Category, Guild
+import utils
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -17,18 +18,18 @@ class End(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
-    @specific_categories_only(
-        category_ids=[
-            config.category_info["pending_seminars"]["id"],
-            config.category_info["ongoing_seminars"]["id"],
-            config.category_info["ongoing_seminars2"]["id"],
-        ]
-    )
+    # @specific_categories_only(
+    #     category_ids=[
+    #         config.category_info["pending_seminars"]["id"],
+    #         config.category_info["ongoing_seminars"]["id"],
+    #         config.category_info["ongoing_seminars2"]["id"],
+    #     ]
+    # )
     @textchannel_only()
     @slash_command(
         name="end",
-        description=f'終了したゼミを{config.category_info["finished_seminars"]["name"]}へ移動させ、ロールを削除します。',
-        guild_ids=[config.guild_id],
+        description='終了したゼミを《ゼミ(終了)》へ移動させ、ロールを削除します。',
+        # guild_ids=[config.guild_id],
     )
     async def end(self, ctx: discord.ApplicationContext):
         # [ give additional information to type checker
@@ -40,14 +41,15 @@ class End(commands.Cog):
 
         # this command must be executed by the leader of the seminar
         # or by someone who has the manage_channels permission
+        finished_category = await utils.get_category(ctx, SeminarState.FINISHED)
         async with async_session() as session:
             async with session.begin():
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).where(
+                            select(Seminar).join(Category).where(
                                 Seminar.channel_id == ctx.channel.id,
-                                Seminar.server_id == ctx.guild_id,
+                                Category.guild_id == ctx.guild_id,
                             )
                         )
                     ).scalar_one()
@@ -64,15 +66,18 @@ class End(commands.Cog):
                     await ctx.respond(embed=embed)
                     return
                 else:
+                    # TODO: FINISHED category を探してそれに対応するレコードを検索する
+                    # /rename ではなく番号づけによって終了できるようにする
+
                     # Check if there's a text channel with the same name in the finished_seminars category.
                     # Tips: Discord does not allow two channels with the same name in the same category.
                     try:
                         (
                             await session.execute(
-                                select(Seminar).where(
+                                select(Seminar).join(Category).where(
                                     Seminar.name == seminar_name,
-                                    Seminar.seminar_state == SeminarState.FINISHED,
-                                    Seminar.server_id == ctx.guild_id,
+                                    Seminar.category_id == finished_category.id,
+                                    Category.guild_id == ctx.guild_id,
                                 )
                             )
                         ).scalar_one()
@@ -81,7 +86,7 @@ class End(commands.Cog):
                     else:
                         embed = discord.Embed(
                             title="<:x:960095353577807883> チャンネル名の重複を検出しました",
-                            description=f'すでに同名のゼミが{config.category_info["finished_seminars"]["name"]}に存在します。ゼミ名を `/rename` してから終了してください。',
+                            description=f'すでに同名のゼミが{finished_category.name}に存在します。ゼミ名を `/rename` してから終了してください。',
                             color=discord.Colour.red(),
                         )
                         await ctx.respond(embed=embed)
@@ -100,9 +105,10 @@ class End(commands.Cog):
             return
 
         # move the text channel to the finished_seminars category
-        finished_seminar_category = ctx.guild.get_channel(
-            config.category_info["finished_seminars"]["id"]
-        )
+        # finished_seminar_category = ctx.guild.get_channel(
+        #     config.category_info["finished_seminars"]["id"]
+        # )
+        finished_seminar_category = await utils.get_category(SeminarState.FINISHED)
         if not isinstance(finished_seminar_category, discord.CategoryChannel):
             embed = discord.Embed(
                 title="<:x:960095353577807883> システムエラー",
@@ -117,7 +123,7 @@ class End(commands.Cog):
         )
         embed = discord.Embed(
             title="<:white_check_mark:960095096563466250> チャンネル移動成功",
-            description=f'チャンネルを{config.category_info["finished_seminars"]["name"]}へ移動しました。',
+            description=f'チャンネルを《{finished_seminar_category.name}》へ移動しました。',
             color=discord.Colour.brand_green(),
         )
         await ctx.respond(embed=embed)
@@ -146,18 +152,29 @@ class End(commands.Cog):
                 # here, it is ensured that the seminar exists in the database
                 this_seminar: Seminar = (
                     await session.execute(
-                        select(Seminar).where(
+                        select(Seminar).join(Category).where(
                             Seminar.channel_id == ctx.channel.id,
-                            Seminar.server_id == ctx.guild_id,
+                            Category.guild_id == ctx.guild_id,
                         )
                     )
                 ).scalar_one()
-                this_seminar.seminar_state = SeminarState.FINISHED
+                this_seminar.category_id = finished_category.id
                 this_seminar.finished_at = datetime.datetime.now()
 
         # delete the message in role_settings channel
+        # role_setting_channel = ctx.guild.get_channel(
+        #     config.channel_info["role_settings"]["id"]
+        # )
+        async with async_session() as session:
+            guild_record = (
+                await session.execute(
+                    select(Guild).where(
+                        Guild.guild_id == ctx.guild_id
+                    )
+                )
+            ).scalar_one_or_none()
         role_setting_channel = ctx.guild.get_channel(
-            config.channel_info["role_settings"]["id"]
+            guild_record.role_setting_channel_id
         )
         if not isinstance(role_setting_channel, discord.TextChannel):
             embed = discord.Embed(
@@ -202,7 +219,7 @@ class End(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description=f'{config.category_info["pending_seminars"]["name"]}または{config.category_info["ongoing_seminars"]["name"]}にあるテキストチャンネルでのみ実行可能です。',
+                description=f'ゼミ(仮立て) または ゼミ(本運用) にあるテキストチャンネルでのみ実行可能です。',
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)

--- a/wathematica_discord_bot/Cogs/SeminarControllers/end.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/end.py
@@ -2,7 +2,7 @@ import datetime
 
 import config
 import discord
-from checks import specific_categories_only, textchannel_only
+from checks import specific_states_only, textchannel_only
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
@@ -25,6 +25,7 @@ class End(commands.Cog):
     #         config.category_info["ongoing_seminars2"]["id"],
     #     ]
     # )
+    @specific_states_only(states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED])
     @textchannel_only()
     @slash_command(
         name="end",

--- a/wathematica_discord_bot/Cogs/SeminarControllers/end.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/end.py
@@ -5,11 +5,7 @@ from checks import specific_states_only, textchannel_only, registered_server_onl
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import (
-    InvalidCategoryException,
-    InvalidChannelTypeException,
-    ConfigurationNotCompleteException,
-)
+from exceptions import *
 from model import Seminar, SeminarState, Category, Guild
 import utils
 from sqlalchemy import select
@@ -228,6 +224,22 @@ class End(commands.Cog):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
                 description="《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
+        if isinstance(error, CategoryNotRegisteredException):
+            embed = discord.Embed(
+                title=":x: チャンネル作成失敗",
+                description="《ゼミ(終了)》カテゴリーが登録されていません。管理者に `/setting` で設定を依頼してください。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
+        if isinstance(error, CategoryUnavailableException):
+            embed = discord.Embed(
+                title=":x: チャンネル作成失敗",
+                description="《ゼミ(終了)》カテゴリーに空きがありません。管理者にカテゴリー作成・設定を依頼してください。",
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)

--- a/wathematica_discord_bot/Cogs/SeminarControllers/end.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/end.py
@@ -1,12 +1,11 @@
 import datetime
 
-import config
 import discord
-from checks import specific_states_only, textchannel_only
+from checks import specific_states_only, textchannel_only, registered_server_only
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException
+from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
 from model import Seminar, SeminarState, Category, Guild
 import utils
 from sqlalchemy import select
@@ -18,13 +17,7 @@ class End(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
-    # @specific_categories_only(
-    #     category_ids=[
-    #         config.category_info["pending_seminars"]["id"],
-    #         config.category_info["ongoing_seminars"]["id"],
-    #         config.category_info["ongoing_seminars2"]["id"],
-    #     ]
-    # )
+    @registered_server_only()
     @specific_states_only(states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED])
     @textchannel_only()
     @slash_command(
@@ -106,9 +99,6 @@ class End(commands.Cog):
             return
 
         # move the text channel to the finished_seminars category
-        # finished_seminar_category = ctx.guild.get_channel(
-        #     config.category_info["finished_seminars"]["id"]
-        # )
         finished_seminar_category = await utils.get_category(SeminarState.FINISHED)
         if not isinstance(finished_seminar_category, discord.CategoryChannel):
             embed = discord.Embed(
@@ -209,6 +199,14 @@ class End(commands.Cog):
     async def end_error(
         self, ctx: discord.ApplicationContext, error: commands.CheckFailure
     ):
+        if isinstance(error, ConfigurationNotCompleteException):
+            embed = discord.Embed(
+                title="<:x:960095353577807883> サーバー設定ができていません",
+                description="管理者に `/setting` で設定を依頼してください。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
         if isinstance(error, InvalidChannelTypeException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",

--- a/wathematica_discord_bot/Cogs/SeminarControllers/end.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/end.py
@@ -5,7 +5,11 @@ from checks import specific_states_only, textchannel_only, registered_server_onl
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
+from exceptions import (
+    InvalidCategoryException,
+    InvalidChannelTypeException,
+    ConfigurationNotCompleteException,
+)
 from model import Seminar, SeminarState, Category, Guild
 import utils
 from sqlalchemy import select
@@ -18,11 +22,13 @@ class End(commands.Cog):
 
     @commands.guild_only()
     @registered_server_only()
-    @specific_states_only(states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED])
+    @specific_states_only(
+        states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED]
+    )
     @textchannel_only()
     @slash_command(
         name="end",
-        description='終了したゼミを《ゼミ(終了)》へ移動させ、ロールを削除します。',
+        description="終了したゼミを《ゼミ(終了)》へ移動させ、ロールを削除します。",
     )
     async def end(self, ctx: discord.ApplicationContext):
         # [ give additional information to type checker
@@ -40,7 +46,9 @@ class End(commands.Cog):
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).join(Category).where(
+                            select(Seminar)
+                            .join(Category)
+                            .where(
                                 Seminar.channel_id == ctx.channel.id,
                                 Category.guild_id == ctx.guild_id,
                             )
@@ -67,7 +75,9 @@ class End(commands.Cog):
                     try:
                         (
                             await session.execute(
-                                select(Seminar).join(Category).where(
+                                select(Seminar)
+                                .join(Category)
+                                .where(
                                     Seminar.name == seminar_name,
                                     Seminar.category_id == finished_category.id,
                                     Category.guild_id == ctx.guild_id,
@@ -79,7 +89,7 @@ class End(commands.Cog):
                     else:
                         embed = discord.Embed(
                             title="<:x:960095353577807883> チャンネル名の重複を検出しました",
-                            description=f'すでに同名のゼミが{finished_category.name}に存在します。ゼミ名を `/rename` してから終了してください。',
+                            description=f"すでに同名のゼミが{finished_category.name}に存在します。ゼミ名を `/rename` してから終了してください。",
                             color=discord.Colour.red(),
                         )
                         await ctx.respond(embed=embed)
@@ -113,7 +123,7 @@ class End(commands.Cog):
         )
         embed = discord.Embed(
             title="<:white_check_mark:960095096563466250> チャンネル移動成功",
-            description=f'チャンネルを《{finished_seminar_category.name}》へ移動しました。',
+            description=f"チャンネルを《{finished_seminar_category.name}》へ移動しました。",
             color=discord.Colour.brand_green(),
         )
         await ctx.respond(embed=embed)
@@ -142,7 +152,9 @@ class End(commands.Cog):
                 # here, it is ensured that the seminar exists in the database
                 this_seminar: Seminar = (
                     await session.execute(
-                        select(Seminar).join(Category).where(
+                        select(Seminar)
+                        .join(Category)
+                        .where(
                             Seminar.channel_id == ctx.channel.id,
                             Category.guild_id == ctx.guild_id,
                         )
@@ -158,9 +170,7 @@ class End(commands.Cog):
         async with async_session() as session:
             guild_record = (
                 await session.execute(
-                    select(Guild).where(
-                        Guild.guild_id == ctx.guild_id
-                    )
+                    select(Guild).where(Guild.guild_id == ctx.guild_id)
                 )
             ).scalar_one_or_none()
         role_setting_channel = ctx.guild.get_channel(
@@ -217,7 +227,7 @@ class End(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description='《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。',
+                description="《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。",
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)

--- a/wathematica_discord_bot/Cogs/SeminarControllers/end.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/end.py
@@ -23,7 +23,6 @@ class End(commands.Cog):
     @slash_command(
         name="end",
         description='終了したゼミを《ゼミ(終了)》へ移動させ、ロールを削除します。',
-        # guild_ids=[config.guild_id],
     )
     async def end(self, ctx: discord.ApplicationContext):
         # [ give additional information to type checker
@@ -218,7 +217,7 @@ class End(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description=f'ゼミ(仮立て) または ゼミ(本運用) にあるテキストチャンネルでのみ実行可能です。',
+                description='《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。',
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)

--- a/wathematica_discord_bot/Cogs/SeminarControllers/help.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/help.py
@@ -1,6 +1,5 @@
 import textwrap
 
-import config
 import discord
 from discord import Option
 from discord.commands import slash_command
@@ -57,10 +56,10 @@ class Help(commands.Cog):
             embed.add_field(
                 name="/begin",
                 value=textwrap.dedent(
-                    f"""
+                    """
                     仮立てのチャンネル内で実行した場合: このゼミを本始動します。
                     休止中のチャンネル内で実行した場合: このゼミを再開します。
-                    テキストチャンネルが{config.category_info["ongoing_seminars"]['name']}カテゴリに移動します。
+                    テキストチャンネルが《ゼミ(本運用)》カテゴリに移動します。
                     """
                 ),
                 inline=False,
@@ -80,9 +79,9 @@ class Help(commands.Cog):
             embed.add_field(
                 name="/pause",
                 value=textwrap.dedent(
-                    f"""
+                    """
                     このゼミを休止します。本運用中のゼミでのみ実行できます。
-                    テキストチャンネルが{config.category_info["paused_seminars"]['name']}カテゴリに移動します。
+                    テキストチャンネルが《ゼミ(休止中)》カテゴリに移動します。
                     """
                 ),
                 inline=False,
@@ -91,9 +90,9 @@ class Help(commands.Cog):
             embed.add_field(
                 name="/end",
                 value=textwrap.dedent(
-                    f"""
+                    """
                     このゼミを終了します。
-                    テキストチャンネルが{config.category_info["finished_seminars"]['name']}に移動され、ロールとロール付与メッセージが削除されます。
+                    テキストチャンネルが《ゼミ(終了)》に移動され、ロールとロール付与メッセージが削除されます。
                     **このコマンドはゼミ長のみが実行できます。**
                     """
                 ),
@@ -139,7 +138,7 @@ class Help(commands.Cog):
     @slash_command(
         name="help",
         description="ヘルプを表示します。",
-        guild_ids=[config.guild_id],
+        # guild_ids=[config.guild_id],
     )
     async def help(
         self,

--- a/wathematica_discord_bot/Cogs/SeminarControllers/leader.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/leader.py
@@ -4,8 +4,12 @@ from checks import specific_states_only, textchannel_only, registered_server_onl
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
-from model import Seminar, SeminarState,Category
+from exceptions import (
+    InvalidCategoryException,
+    InvalidChannelTypeException,
+    ConfigurationNotCompleteException,
+)
+from model import Seminar, SeminarState, Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -16,7 +20,9 @@ class Leader(commands.Cog):
 
     @commands.guild_only()
     @registered_server_only()
-    @specific_states_only(states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED])
+    @specific_states_only(
+        states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED]
+    )
     @textchannel_only()
     @slash_command(
         name="leader",
@@ -37,7 +43,9 @@ class Leader(commands.Cog):
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).join(Category).where(
+                            select(Seminar)
+                            .join(Category)
+                            .where(
                                 Seminar.channel_id == ctx.channel.id,
                                 Category.guild_id == ctx.guild_id,
                             )
@@ -93,7 +101,7 @@ class Leader(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description='《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。',
+                description="《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。",
                 color=discord.Colour.red(),
             )
             await ctx.respond(

--- a/wathematica_discord_bot/Cogs/SeminarControllers/leader.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/leader.py
@@ -1,11 +1,11 @@
 import config
 import discord
-from checks import specific_categories_only, textchannel_only
+from checks import specific_states_only, textchannel_only
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
 from exceptions import InvalidCategoryException, InvalidChannelTypeException
-from model import Seminar, Category
+from model import Seminar, SeminarState,Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -23,6 +23,7 @@ class Leader(commands.Cog):
     #         config.category_info["ongoing_seminars2"]["id"],
     #     ]
     # )
+    @specific_states_only(states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED])
     @textchannel_only()
     @slash_command(
         name="leader",

--- a/wathematica_discord_bot/Cogs/SeminarControllers/leader.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/leader.py
@@ -21,7 +21,6 @@ class Leader(commands.Cog):
     @slash_command(
         name="leader",
         description="このゼミのゼミ長を表示します",
-        # guild_ids=[config.guild_id],
     )
     async def leader(self, ctx: discord.ApplicationContext):
         # [ give additional information to type checker

--- a/wathematica_discord_bot/Cogs/SeminarControllers/leader.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/leader.py
@@ -5,7 +5,7 @@ from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
 from exceptions import InvalidCategoryException, InvalidChannelTypeException
-from model import Seminar
+from model import Seminar, Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -15,19 +15,19 @@ class Leader(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
-    @specific_categories_only(
-        category_ids=[
-            config.category_info["pending_seminars"]["id"],
-            config.category_info["paused_seminars"]["id"],
-            config.category_info["ongoing_seminars"]["id"],
-            config.category_info["ongoing_seminars2"]["id"],
-        ]
-    )
+    # @specific_categories_only(
+    #     category_ids=[
+    #         config.category_info["pending_seminars"]["id"],
+    #         config.category_info["paused_seminars"]["id"],
+    #         config.category_info["ongoing_seminars"]["id"],
+    #         config.category_info["ongoing_seminars2"]["id"],
+    #     ]
+    # )
     @textchannel_only()
     @slash_command(
         name="leader",
         description="このゼミのゼミ長を表示します",
-        guild_ids=[config.guild_id],
+        # guild_ids=[config.guild_id],
     )
     async def leader(self, ctx: discord.ApplicationContext):
         # [ give additional information to type checker
@@ -44,9 +44,9 @@ class Leader(commands.Cog):
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).where(
+                            select(Seminar).join(Category).where(
                                 Seminar.channel_id == ctx.channel.id,
-                                Seminar.server_id == ctx.guild_id,
+                                Category.guild_id == ctx.guild_id,
                             )
                         )
                     ).scalar_one()
@@ -92,7 +92,7 @@ class Leader(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description=f'{config.category_info["pending_seminars"]["name"]}または{config.category_info["ongoing_seminars"]["name"]},{config.category_info["ongoing_seminars2"]["name"]}にあるテキストチャンネルでのみ実行可能です。',
+                description='《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。',
                 color=discord.Colour.red(),
             )
             await ctx.respond(

--- a/wathematica_discord_bot/Cogs/SeminarControllers/leader.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/leader.py
@@ -1,10 +1,10 @@
 import config
 import discord
-from checks import specific_states_only, textchannel_only
+from checks import specific_states_only, textchannel_only, registered_server_only
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException
+from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
 from model import Seminar, SeminarState,Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
@@ -15,14 +15,7 @@ class Leader(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
-    # @specific_categories_only(
-    #     category_ids=[
-    #         config.category_info["pending_seminars"]["id"],
-    #         config.category_info["paused_seminars"]["id"],
-    #         config.category_info["ongoing_seminars"]["id"],
-    #         config.category_info["ongoing_seminars2"]["id"],
-    #     ]
-    # )
+    @registered_server_only()
     @specific_states_only(states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED])
     @textchannel_only()
     @slash_command(
@@ -82,6 +75,14 @@ class Leader(commands.Cog):
     async def leader_error(
         self, ctx: discord.ApplicationContext, error: commands.CheckFailure
     ):
+        if isinstance(error, ConfigurationNotCompleteException):
+            embed = discord.Embed(
+                title="<:x:960095353577807883> サーバー設定ができていません",
+                description="管理者に `/setting` で設定を依頼してください。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
         if isinstance(error, InvalidChannelTypeException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",

--- a/wathematica_discord_bot/Cogs/SeminarControllers/new.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/new.py
@@ -9,6 +9,8 @@ from model import Seminar, SeminarState, Category, Guild
 import utils
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
+from exceptions import ConfigurationNotCompleteException
+from checks import registered_server_only
 
 
 class New(commands.Cog):
@@ -16,6 +18,7 @@ class New(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
+    @registered_server_only()
     @slash_command(
         name="new",
         description="seminar_name が付与されたテキストチャンネルとロールを作成します。",
@@ -224,6 +227,20 @@ class New(commands.Cog):
         async with async_session() as session:
             async with session.begin():
                 session.add(seminar)
+    
+    @new.error
+    async def new_error(
+        self, ctx: discord.ApplicationContext, error: commands.CheckFailure
+    ):
+        if isinstance(error, ConfigurationNotCompleteException):
+            embed = discord.Embed(
+                title="<:x:960095353577807883> サーバー設定ができていません",
+                description="管理者に `/setting` で設定を依頼してください。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
+        raise Exception("Unexpected error occurred.")
 
 
 def setup(bot: discord.Bot):

--- a/wathematica_discord_bot/Cogs/SeminarControllers/new.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/new.py
@@ -22,7 +22,6 @@ class New(commands.Cog):
     @slash_command(
         name="new",
         description="seminar_name が付与されたテキストチャンネルとロールを作成します。",
-        # guild_ids=[config.guild_id],
     )
     async def new(
         self,
@@ -143,16 +142,6 @@ class New(commands.Cog):
                             await ctx.respond(embed=embed)
                             return
 
-        # category = ctx.guild.get_channel(config.category_info["pending_seminars"]["id"])
-        # if not isinstance(category, discord.CategoryChannel):
-        #     embed = discord.Embed(
-        #         title="<:x:960095353577807883> システムエラー",
-        #         description="管理者向けメッセージ: `pending_seminars` カテゴリが見つかりませんでした。",
-        #         color=discord.Colour.red(),
-        #     )
-        #     await ctx.respond(embed=embed)
-        #     return
-
         pending_category = await utils.get_category(ctx, SeminarState.PENDING)
         # create a text channel and a role
         new_text_channel = await pending_category.create_text_channel(name=seminar_name)
@@ -172,9 +161,6 @@ class New(commands.Cog):
         await ctx.respond(embed=embed)
 
         # Send message to role_settings channel in order for users to attach the role to themselves
-        # role_setting_channel = ctx.guild.get_channel(
-        #     config.channel_info["role_settings"]["id"]
-        # )
         role_setting_channel = ctx.guild.get_channel(
             guild_record.role_setting_channel_id
         )
@@ -194,7 +180,6 @@ class New(commands.Cog):
         message_to_role_settings_channel: discord.Message = (
             await role_setting_channel.send(embed=embed_to_role_settings_channel)
         )
-        # interesting_emoji = await ctx.guild.fetch_emoji(config.interesting_emoji_id)
         interesting_emoji = await ctx.guild.fetch_emoji(guild_record.interesting_emoji_id)
         await message_to_role_settings_channel.add_reaction(interesting_emoji)
 
@@ -240,6 +225,7 @@ class New(commands.Cog):
             )
             await ctx.respond(embed=embed)
             return
+        print(f'{type(error)=}')
         raise Exception("Unexpected error occurred.")
 
 

--- a/wathematica_discord_bot/Cogs/SeminarControllers/new.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/new.py
@@ -37,9 +37,7 @@ class New(commands.Cog):
         async with async_session() as session:
             guild_record = (
                 await session.execute(
-                    select(Guild).where(
-                        Guild.guild_id == ctx.guild_id
-                    )
+                    select(Guild).where(Guild.guild_id == ctx.guild_id)
                 )
             ).scalar_one_or_none()
 
@@ -180,7 +178,9 @@ class New(commands.Cog):
         message_to_role_settings_channel: discord.Message = (
             await role_setting_channel.send(embed=embed_to_role_settings_channel)
         )
-        interesting_emoji = await ctx.guild.fetch_emoji(guild_record.interesting_emoji_id)
+        interesting_emoji = await ctx.guild.fetch_emoji(
+            guild_record.interesting_emoji_id
+        )
         await message_to_role_settings_channel.add_reaction(interesting_emoji)
 
         # Prompt users to get the role at role_settings channel
@@ -212,7 +212,7 @@ class New(commands.Cog):
         async with async_session() as session:
             async with session.begin():
                 session.add(seminar)
-    
+
     @new.error
     async def new_error(
         self, ctx: discord.ApplicationContext, error: commands.CheckFailure
@@ -225,7 +225,7 @@ class New(commands.Cog):
             )
             await ctx.respond(embed=embed)
             return
-        print(f'{type(error)=}')
+        print(f"{type(error)=}")
         raise Exception("Unexpected error occurred.")
 
 

--- a/wathematica_discord_bot/Cogs/SeminarControllers/new.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/new.py
@@ -1,12 +1,12 @@
 import datetime
 
-import config
 import discord
 from database import async_session
 from discord import Option
 from discord.commands import slash_command
 from discord.ext import commands
-from model import Seminar, SeminarState
+from model import Seminar, SeminarState, Category, Guild
+import utils
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -19,7 +19,7 @@ class New(commands.Cog):
     @slash_command(
         name="new",
         description="seminar_name が付与されたテキストチャンネルとロールを作成します。",
-        guild_ids=[config.guild_id],
+        # guild_ids=[config.guild_id],
     )
     async def new(
         self,
@@ -31,6 +31,15 @@ class New(commands.Cog):
         # guild_only() decorator ensures that ctx.guild is not None
         assert isinstance(ctx.guild, discord.Guild)
         # ]
+
+        async with async_session() as session:
+            guild_record = (
+                await session.execute(
+                    select(Guild).where(
+                        Guild.guild_id == ctx.guild_id
+                    )
+                )
+            ).scalar_one_or_none()
 
         # TODO: sanitize user's incorrect input patterns (e.g. some users may attach redundant quotation marks around the seminar name)
         seminar_name = seminar_name.lower()  # discord channel names should be lowercase
@@ -51,10 +60,12 @@ class New(commands.Cog):
                 try:
                     (
                         await session.execute(
-                            select(Seminar).where(
+                            select(Seminar)
+                            .join(Category)
+                            .where(
                                 Seminar.name == seminar_name,
-                                Seminar.seminar_state != SeminarState.FINISHED,
-                                Seminar.server_id == ctx.guild_id,
+                                Category.state != SeminarState.FINISHED,
+                                Category.guild_id == ctx.guild_id,
                             )
                         )
                     ).scalar_one()
@@ -68,10 +79,12 @@ class New(commands.Cog):
                         try:
                             (
                                 await session.execute(
-                                    select(Seminar).where(
+                                    select(Seminar)
+                                    .join(Category)
+                                    .where(
                                         Seminar.name == seminar_name_candidate,
-                                        Seminar.seminar_state != SeminarState.FINISHED,
-                                        Seminar.server_id == ctx.guild_id,
+                                        Category.state != SeminarState.FINISHED,
+                                        Category.guild_id == ctx.guild_id,
                                     )
                                 )
                             ).scalar_one()
@@ -127,18 +140,19 @@ class New(commands.Cog):
                             await ctx.respond(embed=embed)
                             return
 
-        category = ctx.guild.get_channel(config.category_info["pending_seminars"]["id"])
-        if not isinstance(category, discord.CategoryChannel):
-            embed = discord.Embed(
-                title="<:x:960095353577807883> システムエラー",
-                description="管理者向けメッセージ: `pending_seminars` カテゴリが見つかりませんでした。",
-                color=discord.Colour.red(),
-            )
-            await ctx.respond(embed=embed)
-            return
+        # category = ctx.guild.get_channel(config.category_info["pending_seminars"]["id"])
+        # if not isinstance(category, discord.CategoryChannel):
+        #     embed = discord.Embed(
+        #         title="<:x:960095353577807883> システムエラー",
+        #         description="管理者向けメッセージ: `pending_seminars` カテゴリが見つかりませんでした。",
+        #         color=discord.Colour.red(),
+        #     )
+        #     await ctx.respond(embed=embed)
+        #     return
 
+        pending_category = await utils.get_category(ctx, SeminarState.PENDING)
         # create a text channel and a role
-        new_text_channel = await category.create_text_channel(name=seminar_name)
+        new_text_channel = await pending_category.create_text_channel(name=seminar_name)
         embed = discord.Embed(
             title="<:white_check_mark:960095096563466250> チャンネル作成成功",
             description=f"チャンネル `{seminar_name}` を作成しました。",
@@ -155,8 +169,11 @@ class New(commands.Cog):
         await ctx.respond(embed=embed)
 
         # Send message to role_settings channel in order for users to attach the role to themselves
+        # role_setting_channel = ctx.guild.get_channel(
+        #     config.channel_info["role_settings"]["id"]
+        # )
         role_setting_channel = ctx.guild.get_channel(
-            config.channel_info["role_settings"]["id"]
+            guild_record.role_setting_channel_id
         )
         if not isinstance(role_setting_channel, discord.TextChannel):
             embed = discord.Embed(
@@ -174,7 +191,8 @@ class New(commands.Cog):
         message_to_role_settings_channel: discord.Message = (
             await role_setting_channel.send(embed=embed_to_role_settings_channel)
         )
-        interesting_emoji = await ctx.guild.fetch_emoji(config.interesting_emoji_id)
+        # interesting_emoji = await ctx.guild.fetch_emoji(config.interesting_emoji_id)
+        interesting_emoji = await ctx.guild.fetch_emoji(guild_record.interesting_emoji_id)
         await message_to_role_settings_channel.add_reaction(interesting_emoji)
 
         # Prompt users to get the role at role_settings channel
@@ -194,11 +212,10 @@ class New(commands.Cog):
 
         # add this seminar to the database
         seminar = Seminar(
-            server_id=ctx.guild.id,
+            category_id=pending_category.id,
             name=seminar_name,
             created_at=datetime.datetime.now(),
             finished_at=None,
-            seminar_state=SeminarState.PENDING,
             leader_id=ctx.author.id,
             channel_id=new_text_channel.id,
             role_id=new_role.id,

--- a/wathematica_discord_bot/Cogs/SeminarControllers/new.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/new.py
@@ -9,7 +9,7 @@ from model import Seminar, SeminarState, Category, Guild
 import utils
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
-from exceptions import ConfigurationNotCompleteException
+from exceptions import ConfigurationNotCompleteException, CategoryUnavailableException, CategoryNotRegisteredException
 from checks import registered_server_only
 
 
@@ -219,13 +219,28 @@ class New(commands.Cog):
     ):
         if isinstance(error, ConfigurationNotCompleteException):
             embed = discord.Embed(
-                title="<:x:960095353577807883> サーバー設定ができていません",
+                title=":x: サーバー設定ができていません",
                 description="管理者に `/setting` で設定を依頼してください。",
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)
             return
-        print(f"{type(error)=}")
+        if isinstance(error, CategoryNotRegisteredException):
+            embed = discord.Embed(
+                title=":x: チャンネル作成失敗",
+                description="《ゼミ(仮立て)》カテゴリーが登録されていません。管理者に `/setting` で設定を依頼してください。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
+        if isinstance(error, CategoryUnavailableException):
+            embed = discord.Embed(
+                title=":x: チャンネル作成失敗",
+                description="《ゼミ(仮立て)》カテゴリーに空きがありません。管理者にカテゴリー作成・設定を依頼してください。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
         raise Exception("Unexpected error occurred.")
 
 

--- a/wathematica_discord_bot/Cogs/SeminarControllers/pause.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/pause.py
@@ -3,7 +3,11 @@ from checks import specific_states_only, textchannel_only, registered_server_onl
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
+from exceptions import (
+    InvalidCategoryException,
+    InvalidChannelTypeException,
+    ConfigurationNotCompleteException,
+)
 from model import Seminar, SeminarState, Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
@@ -20,7 +24,7 @@ class Pause(commands.Cog):
     @textchannel_only()
     @slash_command(
         name="pause",
-        description='ゼミを《ゼミ(本運用)》から《ゼミ(休止中)》に移動させます',
+        description="ゼミを《ゼミ(本運用)》から《ゼミ(休止中)》に移動させます",
     )
     async def pause(self, ctx: discord.ApplicationContext):
         # [ give additional information to type checker
@@ -48,7 +52,9 @@ class Pause(commands.Cog):
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).join(Category).where(
+                            select(Seminar)
+                            .join(Category)
+                            .where(
                                 Seminar.channel_id == ctx.channel.id,
                                 Category.guild_id == ctx.guild_id,
                             )
@@ -65,7 +71,7 @@ class Pause(commands.Cog):
 
         embed = discord.Embed(
             title="<:white_check_mark:960095096563466250> チャンネル移動成功",
-            description=f'チャンネルを《{paused_seminar_category.name}》へ移動しました。',
+            description=f"チャンネルを《{paused_seminar_category.name}》へ移動しました。",
             color=discord.Colour.brand_green(),
         )
         await ctx.respond(embed=embed)
@@ -93,7 +99,7 @@ class Pause(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description='《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。',
+                description="《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。",
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)

--- a/wathematica_discord_bot/Cogs/SeminarControllers/pause.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/pause.py
@@ -1,4 +1,3 @@
-import config
 import discord
 from checks import specific_states_only, textchannel_only, registered_server_only
 from database import async_session
@@ -22,7 +21,6 @@ class Pause(commands.Cog):
     @slash_command(
         name="pause",
         description='ゼミを《ゼミ(本運用)》から《ゼミ(休止中)》に移動させます',
-        # guild_ids=[config.guild_id],
     )
     async def pause(self, ctx: discord.ApplicationContext):
         # [ give additional information to type checker
@@ -30,9 +28,6 @@ class Pause(commands.Cog):
         assert isinstance(ctx.guild, discord.Guild)
         # ]
 
-        # paused_seminar_category = ctx.guild.get_channel(
-        #     config.category_info["paused_seminars"]["id"]
-        # )
         paused_seminar_category = await utils.get_category(ctx, SeminarState.PAUSED)
         if not isinstance(paused_seminar_category, discord.CategoryChannel):
             embed = discord.Embed(

--- a/wathematica_discord_bot/Cogs/SeminarControllers/pause.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/pause.py
@@ -3,11 +3,7 @@ from checks import specific_states_only, textchannel_only, registered_server_onl
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import (
-    InvalidCategoryException,
-    InvalidChannelTypeException,
-    ConfigurationNotCompleteException,
-)
+from exceptions import *
 from model import Seminar, SeminarState, Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
@@ -100,6 +96,22 @@ class Pause(commands.Cog):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
                 description="《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
+        if isinstance(error, CategoryNotRegisteredException):
+            embed = discord.Embed(
+                title=":x: チャンネル作成失敗",
+                description="《ゼミ(休止中)》カテゴリーが登録されていません。管理者に `/setting` で設定を依頼してください。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
+        if isinstance(error, CategoryUnavailableException):
+            embed = discord.Embed(
+                title=":x: チャンネル作成失敗",
+                description="《ゼミ(休止中)》カテゴリーに空きがありません。管理者にカテゴリー作成・設定を依頼してください。",
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)

--- a/wathematica_discord_bot/Cogs/SeminarControllers/pause.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/pause.py
@@ -5,9 +5,10 @@ from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
 from exceptions import InvalidCategoryException, InvalidChannelTypeException
-from model import Seminar, SeminarState
+from model import Seminar, SeminarState, Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
+import utils
 
 
 class Pause(commands.Cog):
@@ -15,17 +16,17 @@ class Pause(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
-    @specific_categories_only(
-        category_ids=[
-            config.category_info["ongoing_seminars"]["id"],
-            config.category_info["ongoing_seminars2"]["id"],
-        ]
-    )
+    # @specific_categories_only(
+    #     category_ids=[
+    #         config.category_info["ongoing_seminars"]["id"],
+    #         config.category_info["ongoing_seminars2"]["id"],
+    #     ]
+    # )
     @textchannel_only()
     @slash_command(
         name="pause",
-        description=f'ゼミを{config.category_info["ongoing_seminars"]["name"]}から{config.category_info["paused_seminars"]["name"]}に移動させます',
-        guild_ids=[config.guild_id],
+        description='ゼミを《ゼミ(本運用)》から《ゼミ(休止中)》に移動させます',
+        # guild_ids=[config.guild_id],
     )
     async def pause(self, ctx: discord.ApplicationContext):
         # [ give additional information to type checker
@@ -33,9 +34,10 @@ class Pause(commands.Cog):
         assert isinstance(ctx.guild, discord.Guild)
         # ]
 
-        paused_seminar_category = ctx.guild.get_channel(
-            config.category_info["paused_seminars"]["id"]
-        )
+        # paused_seminar_category = ctx.guild.get_channel(
+        #     config.category_info["paused_seminars"]["id"]
+        # )
+        paused_seminar_category = await utils.get_category(ctx, SeminarState.PAUSED)
         if not isinstance(paused_seminar_category, discord.CategoryChannel):
             embed = discord.Embed(
                 title="<:x:960095353577807883> システムエラー",
@@ -55,13 +57,13 @@ class Pause(commands.Cog):
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).where(
+                            select(Seminar).join(Category).where(
                                 Seminar.channel_id == ctx.channel.id,
-                                Seminar.server_id == ctx.guild_id,
+                                Category.guild_id == ctx.guild_id,
                             )
                         )
                     ).scalar_one()
-                    this_seminar.seminar_state = SeminarState.PAUSED
+                    this_seminar.category_id = paused_seminar_category.id
                 except NoResultFound:
                     embed = discord.Embed(
                         title="<:warning:960146803846684692> データベース編集失敗",
@@ -72,7 +74,7 @@ class Pause(commands.Cog):
 
         embed = discord.Embed(
             title="<:white_check_mark:960095096563466250> チャンネル移動成功",
-            description=f'チャンネルを{config.category_info["paused_seminars"]["name"]}へ移動しました。',
+            description=f'チャンネルを《{paused_seminar_category.name}》へ移動しました。',
             color=discord.Colour.brand_green(),
         )
         await ctx.respond(embed=embed)
@@ -92,7 +94,7 @@ class Pause(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description=f'{config.category_info["ongoing_seminars"]["name"]}、または{config.category_info["ongoing_seminars2"]["id"]}にあるテキストチャンネルでのみ実行可能です。',
+                description='《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。',
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)

--- a/wathematica_discord_bot/Cogs/SeminarControllers/pause.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/pause.py
@@ -1,10 +1,10 @@
 import config
 import discord
-from checks import specific_states_only, textchannel_only
+from checks import specific_states_only, textchannel_only, registered_server_only
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException
+from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
 from model import Seminar, SeminarState, Category
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
@@ -16,12 +16,7 @@ class Pause(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
-    # @specific_categories_only(
-    #     category_ids=[
-    #         config.category_info["ongoing_seminars"]["id"],
-    #         config.category_info["ongoing_seminars2"]["id"],
-    #     ]
-    # )
+    @registered_server_only()
     @specific_states_only(states=[SeminarState.ONGOING])
     @textchannel_only()
     @slash_command(
@@ -84,6 +79,14 @@ class Pause(commands.Cog):
     async def pause_error(
         self, ctx: discord.ApplicationContext, error: commands.CheckFailure
     ):
+        if isinstance(error, ConfigurationNotCompleteException):
+            embed = discord.Embed(
+                title="<:x:960095353577807883> サーバー設定ができていません",
+                description="管理者に `/setting` で設定を依頼してください。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
         if isinstance(error, InvalidChannelTypeException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",

--- a/wathematica_discord_bot/Cogs/SeminarControllers/pause.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/pause.py
@@ -1,6 +1,6 @@
 import config
 import discord
-from checks import specific_categories_only, textchannel_only
+from checks import specific_states_only, textchannel_only
 from database import async_session
 from discord.commands import slash_command
 from discord.ext import commands
@@ -22,6 +22,7 @@ class Pause(commands.Cog):
     #         config.category_info["ongoing_seminars2"]["id"],
     #     ]
     # )
+    @specific_states_only(states=[SeminarState.ONGOING])
     @textchannel_only()
     @slash_command(
         name="pause",

--- a/wathematica_discord_bot/Cogs/SeminarControllers/rename.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/rename.py
@@ -1,11 +1,11 @@
 import config
 import discord
-from checks import specific_states_only, textchannel_only
+from checks import specific_states_only, textchannel_only, registered_server_only
 from database import async_session
 from discord import NotFound, Option
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException
+from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
 from model import Seminar, SeminarState, Category, Guild
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
@@ -16,13 +16,7 @@ class Rename(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
-    # @specific_categories_only(
-    #     category_ids=[
-    #         config.category_info["pending_seminars"]["id"],
-    #         config.category_info["ongoing_seminars"]["id"],
-    #         config.category_info["ongoing_seminars2"]["id"],
-    #     ]
-    # )
+    @registered_server_only()
     @specific_states_only(states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED])
     @textchannel_only()
     @slash_command(
@@ -186,6 +180,14 @@ class Rename(commands.Cog):
     async def rename_error(
         self, ctx: discord.ApplicationContext, error: commands.CheckFailure
     ):
+        if isinstance(error, ConfigurationNotCompleteException):
+            embed = discord.Embed(
+                title="<:x:960095353577807883> サーバー設定ができていません",
+                description="管理者に `/setting` で設定を依頼してください。",
+                color=discord.Colour.red(),
+            )
+            await ctx.respond(embed=embed)
+            return
         if isinstance(error, InvalidChannelTypeException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",

--- a/wathematica_discord_bot/Cogs/SeminarControllers/rename.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/rename.py
@@ -6,7 +6,7 @@ from discord import NotFound, Option
 from discord.commands import slash_command
 from discord.ext import commands
 from exceptions import InvalidCategoryException, InvalidChannelTypeException
-from model import Seminar, SeminarState
+from model import Seminar, SeminarState, Category, Guild
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -16,18 +16,18 @@ class Rename(commands.Cog):
         self.bot = bot
 
     @commands.guild_only()
-    @specific_categories_only(
-        category_ids=[
-            config.category_info["pending_seminars"]["id"],
-            config.category_info["ongoing_seminars"]["id"],
-            config.category_info["ongoing_seminars2"]["id"],
-        ]
-    )
+    # @specific_categories_only(
+    #     category_ids=[
+    #         config.category_info["pending_seminars"]["id"],
+    #         config.category_info["ongoing_seminars"]["id"],
+    #         config.category_info["ongoing_seminars2"]["id"],
+    #     ]
+    # )
     @textchannel_only()
     @slash_command(
         name="rename",
         description="ゼミを改名します。テキストチャンネルとロールの名前が変化します。",
-        guild_ids=[config.guild_id],
+        # guild_ids=[config.guild_id],
     )
     async def rename(
         self,
@@ -58,10 +58,10 @@ class Rename(commands.Cog):
                 try:
                     (
                         await session.execute(
-                            select(Seminar).where(
+                            select(Seminar).join(Category).where(
                                 Seminar.name == new_name,
-                                Seminar.seminar_state != SeminarState.FINISHED,
-                                Seminar.server_id == ctx.guild_id,
+                                Category.state != SeminarState.FINISHED,
+                                Category.guild_id == ctx.guild_id,
                             )
                         )
                     ).scalar_one()
@@ -81,9 +81,9 @@ class Rename(commands.Cog):
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).where(
+                            select(Seminar).join(Category).where(
                                 Seminar.channel_id == ctx.channel.id,
-                                Seminar.server_id == ctx.guild_id,
+                                Category.guild_id == ctx.guild_id,
                             )
                         )
                     ).scalar_one()
@@ -136,7 +136,18 @@ class Rename(commands.Cog):
                     this_seminar.name = new_name
 
         # edit the message that is already sent to role_settings channel
-        role_channel = ctx.guild.get_channel(config.channel_info["role_settings"]["id"])
+        # role_channel = ctx.guild.get_channel(config.channel_info["role_settings"]["id"])
+        async with async_session() as session:
+            guild_record = (
+                await session.execute(
+                    select(Guild).where(
+                        Guild.guild_id == ctx.guild_id
+                    )
+                )
+            ).scalar_one_or_none()
+        role_channel = ctx.guild.get_channel(
+            guild_record.role_setting_channel_id
+        )
         if not isinstance(role_channel, discord.TextChannel):
             embed = discord.Embed(
                 title="<:x:960095353577807883> システムエラー",
@@ -185,7 +196,7 @@ class Rename(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description=f'{config.category_info["pending_seminars"]["name"]}または{config.category_info["ongoing_seminars"]["name"]}にあるテキストチャンネルでのみ実行可能です。',
+                description='《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。',
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)

--- a/wathematica_discord_bot/Cogs/SeminarControllers/rename.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/rename.py
@@ -1,4 +1,3 @@
-import config
 import discord
 from checks import specific_states_only, textchannel_only, registered_server_only
 from database import async_session
@@ -22,7 +21,6 @@ class Rename(commands.Cog):
     @slash_command(
         name="rename",
         description="ゼミを改名します。テキストチャンネルとロールの名前が変化します。",
-        # guild_ids=[config.guild_id],
     )
     async def rename(
         self,

--- a/wathematica_discord_bot/Cogs/SeminarControllers/rename.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/rename.py
@@ -1,6 +1,6 @@
 import config
 import discord
-from checks import specific_categories_only, textchannel_only
+from checks import specific_states_only, textchannel_only
 from database import async_session
 from discord import NotFound, Option
 from discord.commands import slash_command
@@ -23,6 +23,7 @@ class Rename(commands.Cog):
     #         config.category_info["ongoing_seminars2"]["id"],
     #     ]
     # )
+    @specific_states_only(states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED])
     @textchannel_only()
     @slash_command(
         name="rename",

--- a/wathematica_discord_bot/Cogs/SeminarControllers/rename.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/rename.py
@@ -4,7 +4,11 @@ from database import async_session
 from discord import NotFound, Option
 from discord.commands import slash_command
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
+from exceptions import (
+    InvalidCategoryException,
+    InvalidChannelTypeException,
+    ConfigurationNotCompleteException,
+)
 from model import Seminar, SeminarState, Category, Guild
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
@@ -16,7 +20,9 @@ class Rename(commands.Cog):
 
     @commands.guild_only()
     @registered_server_only()
-    @specific_states_only(states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED])
+    @specific_states_only(
+        states=[SeminarState.PENDING, SeminarState.ONGOING, SeminarState.PAUSED]
+    )
     @textchannel_only()
     @slash_command(
         name="rename",
@@ -51,7 +57,9 @@ class Rename(commands.Cog):
                 try:
                     (
                         await session.execute(
-                            select(Seminar).join(Category).where(
+                            select(Seminar)
+                            .join(Category)
+                            .where(
                                 Seminar.name == new_name,
                                 Category.state != SeminarState.FINISHED,
                                 Category.guild_id == ctx.guild_id,
@@ -74,7 +82,9 @@ class Rename(commands.Cog):
                 try:
                     this_seminar: Seminar = (
                         await session.execute(
-                            select(Seminar).join(Category).where(
+                            select(Seminar)
+                            .join(Category)
+                            .where(
                                 Seminar.channel_id == ctx.channel.id,
                                 Category.guild_id == ctx.guild_id,
                             )
@@ -133,14 +143,10 @@ class Rename(commands.Cog):
         async with async_session() as session:
             guild_record = (
                 await session.execute(
-                    select(Guild).where(
-                        Guild.guild_id == ctx.guild_id
-                    )
+                    select(Guild).where(Guild.guild_id == ctx.guild_id)
                 )
             ).scalar_one_or_none()
-        role_channel = ctx.guild.get_channel(
-            guild_record.role_setting_channel_id
-        )
+        role_channel = ctx.guild.get_channel(guild_record.role_setting_channel_id)
         if not isinstance(role_channel, discord.TextChannel):
             embed = discord.Embed(
                 title="<:x:960095353577807883> システムエラー",
@@ -197,7 +203,7 @@ class Rename(commands.Cog):
         if isinstance(error, InvalidCategoryException):
             embed = discord.Embed(
                 title="<:x:960095353577807883> 不正な操作です",
-                description='《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。',
+                description="《ゼミ(仮立て)》または《ゼミ(本運用)》にあるテキストチャンネルでのみ実行可能です。",
                 color=discord.Colour.red(),
             )
             await ctx.respond(embed=embed)

--- a/wathematica_discord_bot/Cogs/SeminarControllers/schedule.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/schedule.py
@@ -13,7 +13,7 @@ class Schedule(commands.Cog):
     @slash_command(
         name="schedule",
         description="日程調整用のメッセージを送信します。",
-        guild_ids=[config.guild_id],
+        # guild_ids=[config.guild_id],
     )
     async def schedule(
         self,

--- a/wathematica_discord_bot/Cogs/SeminarControllers/schedule.py
+++ b/wathematica_discord_bot/Cogs/SeminarControllers/schedule.py
@@ -1,4 +1,3 @@
-import config
 import discord
 from discord import Option
 from discord.commands import slash_command
@@ -13,7 +12,6 @@ class Schedule(commands.Cog):
     @slash_command(
         name="schedule",
         description="日程調整用のメッセージを送信します。",
-        # guild_ids=[config.guild_id],
     )
     async def schedule(
         self,

--- a/wathematica_discord_bot/Cogs/UserControllers/assign_role.py
+++ b/wathematica_discord_bot/Cogs/UserControllers/assign_role.py
@@ -22,9 +22,7 @@ class RoleAssigner(commands.Cog):
         async with async_session() as session:
             guild_record = (
                 await session.execute(
-                    select(Guild).where(
-                        Guild.guild_id == payload.guild_id
-                    )
+                    select(Guild).where(Guild.guild_id == payload.guild_id)
                 )
             ).scalar_one_or_none()
 

--- a/wathematica_discord_bot/Cogs/UserControllers/assign_role.py
+++ b/wathematica_discord_bot/Cogs/UserControllers/assign_role.py
@@ -2,7 +2,7 @@ import config
 import discord
 from database import async_session
 from discord.ext import commands
-from model import Seminar
+from model import Seminar, Guild
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -19,11 +19,20 @@ class RoleAssigner(commands.Cog):
         # ignore reactions from bot
         if member.bot:
             return
+        async with async_session() as session:
+            guild_record = (
+                await session.execute(
+                    select(Guild).where(
+                        Guild.guild_id == payload.guild_id
+                    )
+                )
+            ).scalar_one_or_none()
+
         # ignore reactions that happens in channels other than role_setting channel
-        if payload.channel_id != config.channel_info["role_settings"]["id"]:
+        if payload.channel_id != guild_record.role_setting_channel_id:
             return
         # react only to "interesting" emoji
-        if payload.emoji.id != config.interesting_emoji_id:
+        if payload.emoji.id != guild_record.interesting_emoji_id:
             return
         # ignore reactions attached to messages other than bot's message
         channel = self.bot.get_channel(payload.channel_id)

--- a/wathematica_discord_bot/Cogs/UserControllers/remove_role.py
+++ b/wathematica_discord_bot/Cogs/UserControllers/remove_role.py
@@ -22,9 +22,7 @@ class RoleRemover(commands.Cog):
         async with async_session() as session:
             guild_record = (
                 await session.execute(
-                    select(Guild).where(
-                        Guild.guild_id == payload.guild_id
-                    )
+                    select(Guild).where(Guild.guild_id == payload.guild_id)
                 )
             ).scalar_one_or_none()
 

--- a/wathematica_discord_bot/Cogs/UserControllers/remove_role.py
+++ b/wathematica_discord_bot/Cogs/UserControllers/remove_role.py
@@ -2,7 +2,7 @@ import config
 import discord
 from database import async_session
 from discord.ext import commands
-from model import Seminar
+from model import Seminar, Guild
 from sqlalchemy import select
 from sqlalchemy.exc import NoResultFound
 
@@ -19,6 +19,15 @@ class RoleRemover(commands.Cog):
         # with payload.member, so fetch_message method is necessarily used here.
         if not payload.guild_id:
             return
+        async with async_session() as session:
+            guild_record = (
+                await session.execute(
+                    select(Guild).where(
+                        Guild.guild_id == payload.guild_id
+                    )
+                )
+            ).scalar_one_or_none()
+
         guild = self.bot.get_guild(payload.guild_id)
         if not guild:
             return
@@ -27,10 +36,10 @@ class RoleRemover(commands.Cog):
         if member.bot:
             return
         # ignore reactions that happens in channels other than role_setting channel
-        if payload.channel_id != config.channel_info["role_settings"]["id"]:
+        if payload.channel_id != guild_record.role_setting_channel_id:
             return
         # react only to "interesting" emoji
-        if payload.emoji.id != config.interesting_emoji_id:
+        if payload.emoji.id != guild_record.interesting_emoji_id:
             return
         channel = self.bot.get_channel(payload.channel_id)
         if not isinstance(channel, discord.TextChannel):

--- a/wathematica_discord_bot/Cogs/guild_controllers.py
+++ b/wathematica_discord_bot/Cogs/guild_controllers.py
@@ -1,0 +1,20 @@
+import glob
+
+from discord.ext import commands
+
+
+class GuildControllers(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        cog_filenames: list[str] = glob.glob(
+            "Cogs/GuildControllers/[a-zA-Z]*.py"
+        )  # exclude __init__.py
+        cogs = list(
+            map(lambda x: x.replace("/", ".").replace(".py", ""), cog_filenames)
+        )
+        for cog in cogs:
+            self.bot.load_extension(cog)
+
+
+def setup(bot: commands.Bot):
+    bot.add_cog(GuildControllers(bot))

--- a/wathematica_discord_bot/app.py
+++ b/wathematica_discord_bot/app.py
@@ -53,6 +53,7 @@ if __name__ == "__main__":
     bot.load_extension("Cogs.admin_tools")
     bot.load_extension("Cogs.seminar_controllers")
     bot.load_extension("Cogs.user_controllers")
+    bot.load_extension("Cogs.guild_controllers")
     if os.path.exists("/run/secrets/discord_token"):
         with open("/run/secrets/discord_token") as discord_token_file:
             # Strip the tailing newline character with strip()

--- a/wathematica_discord_bot/checks.py
+++ b/wathematica_discord_bot/checks.py
@@ -1,6 +1,9 @@
 import discord
 from discord.ext import commands
 from exceptions import InvalidCategoryException, InvalidChannelTypeException
+from model import SeminarState, Category
+from database import async_session
+from sqlalchemy import select
 
 
 def specific_categories_only(category_ids: list[int]):
@@ -18,6 +21,42 @@ def specific_categories_only(category_ids: list[int]):
 
     async def predicate(ctx: discord.ApplicationContext) -> bool:
         if ctx.channel.category_id in category_ids:
+            return True
+        else:
+            raise InvalidCategoryException(
+                "Command was executed in an invalid category"
+            )
+
+    return commands.check(predicate)
+
+def specific_states_only(states: list[SeminarState]):
+    """
+    Parameters:
+        states: list[SeminarState]
+            
+    Return:
+        _ : bool
+    Raises:
+
+    """
+    async def predicate(ctx: discord.ApplicationContext) -> bool:
+        # ctx の category を DB から検索してその state を取得する
+        async with async_session() as session:
+            category_record = (
+                await session.execute(
+                    select(Category).where(
+                        Category.category_id == ctx.channel.category_id
+                    )
+                )
+            ).scalar_one_or_none()
+        
+        if not category_record:
+            # サーバー設定をする必要がある，という ERROR 
+            raise Exception(
+                "There is no server settings."
+            )
+
+        if category_record.state in states:
             return True
         else:
             raise InvalidCategoryException(

--- a/wathematica_discord_bot/checks.py
+++ b/wathematica_discord_bot/checks.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
+from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException, HasEngineerRoleException
 from model import SeminarState, Category, Guild
 from database import async_session
 from sqlalchemy import select
@@ -111,14 +111,41 @@ def registered_server_only():
             raise ConfigurationNotCompleteException(
                 "Server setting was not completed"
             )
-        
-        if not all([
+
+        if all([
             guild_record.interesting_emoji_id,
             guild_record.engineer_role_id,
             guild_record.role_setting_channel_id,
             guild_record.system_channel_id,
         ]):
+            return True
+        else:
             raise ConfigurationNotCompleteException(
                 "Server setting was not completed"
+            )
+    return commands.check(predicate)
+
+
+def has_engineer_role_only():
+    async def predicate(ctx: discord.ApplicationContext) -> bool:
+        async with async_session() as session:
+            guild_record = (
+                await session.execute(
+                    select(Guild).where(
+                        Guild.guild_id == ctx.guild_id
+                    )
+                )
+            ).scalar_one_or_none()
+
+        if not guild_record:
+            raise ConfigurationNotCompleteException(
+                "Server setting was not completed"
+            )
+
+        if guild_record.engineer_role_id in ctx.author.roles:
+            return True
+        else:
+            raise HasEngineerRoleException(
+                "Command was used by non engineer role user"
             )
     return commands.check(predicate)

--- a/wathematica_discord_bot/checks.py
+++ b/wathematica_discord_bot/checks.py
@@ -52,8 +52,8 @@ def specific_states_only(states: list[SeminarState]):
         
         if not category_record:
             # サーバー設定をする必要がある，という ERROR 
-            raise Exception(
-                "There is no server settings."
+            raise InvalidCategoryException(
+                "Command was executed in a category that is not registered in the datebase"
             )
 
         if category_record.state in states:

--- a/wathematica_discord_bot/checks.py
+++ b/wathematica_discord_bot/checks.py
@@ -1,7 +1,7 @@
 import discord
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException
-from model import SeminarState, Category
+from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException
+from model import SeminarState, Category, Guild
 from database import async_session
 from sqlalchemy import select
 
@@ -85,4 +85,40 @@ def textchannel_only():
                 "Command was executed in an invalid channel"
             )
 
+    return commands.check(predicate)
+
+
+def registered_server_only():
+    """
+    Returns:
+        _ : bool
+            whether the settings was completed
+    Raises:
+        ConfigurationNotCompleteException
+            raised when the settings of the server was not completed.
+    """
+
+    async def predicate(ctx: discord.ApplicationContext) -> bool:
+        async with async_session() as session:
+            guild_record = (
+                await session.execute(
+                    select(Guild).where(
+                        Guild.guild_id == ctx.guild_id
+                    )
+                )
+            ).scalar_one_or_none()
+        if not guild_record:
+            raise ConfigurationNotCompleteException(
+                "Server setting was not completed"
+            )
+        
+        if not all([
+            guild_record.interesting_emoji_id,
+            guild_record.engineer_role_id,
+            guild_record.role_setting_channel_id,
+            guild_record.system_channel_id,
+        ]):
+            raise ConfigurationNotCompleteException(
+                "Server setting was not completed"
+            )
     return commands.check(predicate)

--- a/wathematica_discord_bot/checks.py
+++ b/wathematica_discord_bot/checks.py
@@ -1,6 +1,11 @@
 import discord
 from discord.ext import commands
-from exceptions import InvalidCategoryException, InvalidChannelTypeException, ConfigurationNotCompleteException, HasEngineerRoleException
+from exceptions import (
+    InvalidCategoryException,
+    InvalidChannelTypeException,
+    ConfigurationNotCompleteException,
+    HasEngineerRoleException,
+)
 from model import SeminarState, Category, Guild
 from database import async_session
 from sqlalchemy import select
@@ -29,6 +34,7 @@ def specific_categories_only(category_ids: list[int]):
 
     return commands.check(predicate)
 
+
 def specific_states_only(states: list[SeminarState]):
     """
     Parameters:
@@ -51,7 +57,7 @@ def specific_states_only(states: list[SeminarState]):
                     )
                 )
             ).scalar_one_or_none()
-        
+
         if not category_record:
             raise InvalidCategoryException(
                 "Command was executed in a category that is not registered in the datebase"
@@ -102,27 +108,24 @@ def registered_server_only():
         async with async_session() as session:
             guild_record = (
                 await session.execute(
-                    select(Guild).where(
-                        Guild.guild_id == ctx.guild_id
-                    )
+                    select(Guild).where(Guild.guild_id == ctx.guild_id)
                 )
             ).scalar_one_or_none()
         if not guild_record:
-            raise ConfigurationNotCompleteException(
-                "Server setting was not completed"
-            )
+            raise ConfigurationNotCompleteException("Server setting was not completed")
 
-        if all([
-            guild_record.interesting_emoji_id,
-            guild_record.engineer_role_id,
-            guild_record.role_setting_channel_id,
-            guild_record.system_channel_id,
-        ]):
+        if all(
+            [
+                guild_record.interesting_emoji_id,
+                guild_record.engineer_role_id,
+                guild_record.role_setting_channel_id,
+                guild_record.system_channel_id,
+            ]
+        ):
             return True
         else:
-            raise ConfigurationNotCompleteException(
-                "Server setting was not completed"
-            )
+            raise ConfigurationNotCompleteException("Server setting was not completed")
+
     return commands.check(predicate)
 
 
@@ -131,21 +134,16 @@ def has_engineer_role_only():
         async with async_session() as session:
             guild_record = (
                 await session.execute(
-                    select(Guild).where(
-                        Guild.guild_id == ctx.guild_id
-                    )
+                    select(Guild).where(Guild.guild_id == ctx.guild_id)
                 )
             ).scalar_one_or_none()
 
         if not guild_record:
-            raise ConfigurationNotCompleteException(
-                "Server setting was not completed"
-            )
+            raise ConfigurationNotCompleteException("Server setting was not completed")
 
         if guild_record.engineer_role_id in ctx.author.roles:
             return True
         else:
-            raise HasEngineerRoleException(
-                "Command was used by non engineer role user"
-            )
+            raise HasEngineerRoleException("Command was used by non engineer role user")
+
     return commands.check(predicate)

--- a/wathematica_discord_bot/checks.py
+++ b/wathematica_discord_bot/checks.py
@@ -33,14 +33,16 @@ def specific_states_only(states: list[SeminarState]):
     """
     Parameters:
         states: list[SeminarState]
-            
+            states of categories where this command can be executed.
     Return:
         _ : bool
+            whether the category where this command was executed matched any of states.
     Raises:
-
+        InvalidCategoryException
+            raised when the category where this command was executed matched none of states.
     """
+
     async def predicate(ctx: discord.ApplicationContext) -> bool:
-        # ctx の category を DB から検索してその state を取得する
         async with async_session() as session:
             category_record = (
                 await session.execute(
@@ -51,7 +53,6 @@ def specific_states_only(states: list[SeminarState]):
             ).scalar_one_or_none()
         
         if not category_record:
-            # サーバー設定をする必要がある，という ERROR 
             raise InvalidCategoryException(
                 "Command was executed in a category that is not registered in the datebase"
             )

--- a/wathematica_discord_bot/exceptions.py
+++ b/wathematica_discord_bot/exceptions.py
@@ -7,3 +7,11 @@ class InvalidCategoryException(discord.CheckFailure):
 
 class InvalidChannelTypeException(discord.CheckFailure):
     pass
+
+
+class ConfigurationNotCompleteException(discord.CheckFailure):
+    pass
+
+
+class SystemChannelOnlyException(discord.CheckFailure):
+    pass

--- a/wathematica_discord_bot/exceptions.py
+++ b/wathematica_discord_bot/exceptions.py
@@ -19,3 +19,12 @@ class SystemChannelOnlyException(discord.CheckFailure):
 
 class HasEngineerRoleException(discord.CheckFailure):
     pass
+
+
+class CategoryNotRegisteredException(discord.CheckFailure):
+    pass
+
+
+class CategoryUnavailableException(discord.CheckFailure):
+    pass
+

--- a/wathematica_discord_bot/exceptions.py
+++ b/wathematica_discord_bot/exceptions.py
@@ -15,3 +15,7 @@ class ConfigurationNotCompleteException(discord.CheckFailure):
 
 class SystemChannelOnlyException(discord.CheckFailure):
     pass
+
+
+class HasEngineerRoleException(discord.CheckFailure):
+    pass

--- a/wathematica_discord_bot/model.py
+++ b/wathematica_discord_bot/model.py
@@ -2,6 +2,7 @@ import datetime
 import enum
 from typing import Optional
 
+from sqlalchemy import ForeignKey
 from sqlalchemy.orm import DeclarativeBase, Mapped, MappedAsDataclass, mapped_column
 
 
@@ -18,18 +19,48 @@ class Base(DeclarativeBase, MappedAsDataclass):
     pass
 
 
-# Table definition
+# table definition
+# for guild
+class Guild(Base):
+    __tablename__ = "guild"
+
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    guild_id: Mapped[int] = mapped_column(unique=True)
+    name: Mapped[str]
+
+    interesting_emoji_id: Mapped[Optional[int]] = mapped_column(default=None)
+    role_setting_channel_id: Mapped[Optional[int]] = mapped_column(default=None)
+    system_channel_id: Mapped[Optional[int]] = mapped_column(default=None)
+    engineer_role_id: Mapped[Optional[int]] = mapped_column(default=None)
+
+
+# for category
+class Category(Base):
+    __tablename__ = "category"
+
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    category_id: Mapped[int] = mapped_column(unique=True)
+    name: Mapped[str]
+
+    guild_id: Mapped[int] = mapped_column(ForeignKey("guild.guild_id"))
+    state: Mapped[SeminarState]
+    category_type: Mapped[str] = mapped_column(default="regular")
+
+
+# for seminar
 class Seminar(Base):
     __tablename__ = "seminar"
 
     # id will be automatically assigned by the database, so it should not be initialized in the constructor
     id: Mapped[int] = mapped_column(primary_key=True, init=False)
-    server_id: Mapped[int]
+
+    category_id: Mapped[int] = mapped_column(ForeignKey("category.category_id"))
+
     name: Mapped[str]
     created_at: Mapped[datetime.datetime]
     finished_at: Mapped[Optional[datetime.datetime]]
-    seminar_state: Mapped[SeminarState]
     leader_id: Mapped[int]
+
     channel_id: Mapped[int] = mapped_column(unique=True)
     role_id: Mapped[int] = mapped_column(unique=True)
     role_setting_message_id: Mapped[int] = mapped_column(unique=True)

--- a/wathematica_discord_bot/utils.py
+++ b/wathematica_discord_bot/utils.py
@@ -3,6 +3,8 @@ from database import async_session
 from sqlalchemy import select
 from model import SeminarState, Category
 
+
+
 state2name = {
     SeminarState.PENDING:   "仮立て",
     SeminarState.ONGOING:   "本運用",

--- a/wathematica_discord_bot/utils.py
+++ b/wathematica_discord_bot/utils.py
@@ -2,14 +2,7 @@ import discord
 from database import async_session
 from sqlalchemy import select
 from model import SeminarState, Category
-
-
-state2name = {
-    SeminarState.PENDING: "仮立て",
-    SeminarState.ONGOING: "本運用",
-    SeminarState.PAUSED: "休止中",
-    SeminarState.FINISHED: "終了",
-}
+from exceptions import CategoryNotRegisteredException, CategoryUnavailableException
 
 
 async def get_category(
@@ -17,7 +10,6 @@ async def get_category(
 ) -> discord.CategoryChannel:
     # find PENDING category
     async with async_session() as session:
-        # PENDING 用として登録されているカテゴリーをすべて取得
         records = (
             (
                 await session.execute(
@@ -32,10 +24,7 @@ async def get_category(
         )
 
     if not records:
-        await ctx.respond(
-            f":x: ゼミ({state2name[state]}) カテゴリーが登録されていません。管理者に `/setting` で設定を依頼してください。"
-        )
-        return
+        raise CategoryNotRegisteredException
 
     target_category: discord.CategoryChannel | None = None
     for cat_record in records:
@@ -48,9 +37,6 @@ async def get_category(
             break
 
     if not target_category:
-        await ctx.respond(
-            f":warning: すべての ゼミ({state2name[state]}) カテゴリーが満杯です！新しくカテゴリーを作成して設定してください。"
-        )
-        return
+        raise CategoryUnavailableException
 
     return target_category

--- a/wathematica_discord_bot/utils.py
+++ b/wathematica_discord_bot/utils.py
@@ -4,29 +4,37 @@ from sqlalchemy import select
 from model import SeminarState, Category
 
 
-
 state2name = {
-    SeminarState.PENDING:   "仮立て",
-    SeminarState.ONGOING:   "本運用",
-    SeminarState.PAUSED:    "休止中",
-    SeminarState.FINISHED:  "終了",
+    SeminarState.PENDING: "仮立て",
+    SeminarState.ONGOING: "本運用",
+    SeminarState.PAUSED: "休止中",
+    SeminarState.FINISHED: "終了",
 }
 
-async def get_category(ctx: discord.ApplicationContext, state: SeminarState, limit_count: bool = True) -> discord.CategoryChannel:
+
+async def get_category(
+    ctx: discord.ApplicationContext, state: SeminarState, limit_count: bool = True
+) -> discord.CategoryChannel:
     # find PENDING category
     async with async_session() as session:
         # PENDING 用として登録されているカテゴリーをすべて取得
         records = (
-            await session.execute(
-                select(Category).where(
-                    Category.guild_id == ctx.guild.id,
-                    Category.state == state,
+            (
+                await session.execute(
+                    select(Category).where(
+                        Category.guild_id == ctx.guild.id,
+                        Category.state == state,
+                    )
                 )
             )
-        ).scalars().all()
+            .scalars()
+            .all()
+        )
 
     if not records:
-        await ctx.respond(f":x: ゼミ({state2name[state]}) カテゴリーが登録されていません。管理者に `/setting` で設定を依頼してください。")
+        await ctx.respond(
+            f":x: ゼミ({state2name[state]}) カテゴリーが登録されていません。管理者に `/setting` で設定を依頼してください。"
+        )
         return
 
     target_category: discord.CategoryChannel | None = None
@@ -40,7 +48,9 @@ async def get_category(ctx: discord.ApplicationContext, state: SeminarState, lim
             break
 
     if not target_category:
-        await ctx.respond(f":warning: すべての ゼミ({state2name[state]}) カテゴリーが満杯です！新しくカテゴリーを作成して設定してください。")
+        await ctx.respond(
+            f":warning: すべての ゼミ({state2name[state]}) カテゴリーが満杯です！新しくカテゴリーを作成して設定してください。"
+        )
         return
-    
+
     return target_category

--- a/wathematica_discord_bot/utils.py
+++ b/wathematica_discord_bot/utils.py
@@ -1,0 +1,44 @@
+import discord
+from database import async_session
+from sqlalchemy import select
+from model import SeminarState, Category
+
+state2name = {
+    SeminarState.PENDING:   "仮立て",
+    SeminarState.ONGOING:   "本運用",
+    SeminarState.PAUSED:    "休止中",
+    SeminarState.FINISHED:  "終了",
+}
+
+async def get_category(ctx: discord.ApplicationContext, state: SeminarState, limit_count: bool = True) -> discord.CategoryChannel:
+    # find PENDING category
+    async with async_session() as session:
+        # PENDING 用として登録されているカテゴリーをすべて取得
+        records = (
+            await session.execute(
+                select(Category).where(
+                    Category.guild_id == ctx.guild.id,
+                    Category.state == state,
+                )
+            )
+        ).scalars().all()
+
+    if not records:
+        await ctx.respond(f":x: ゼミ({state2name[state]}) カテゴリーが登録されていません。管理者に `/setting` で設定を依頼してください。")
+        return
+
+    target_category: discord.CategoryChannel | None = None
+    for cat_record in records:
+        cat = ctx.guild.get_channel(cat_record.category_id)
+        if not isinstance(cat, discord.CategoryChannel):
+            continue
+
+        if limit_count and len(cat.channels) < 45:
+            target_category = cat
+            break
+
+    if not target_category:
+        await ctx.respond(f":warning: すべての ゼミ({state2name[state]}) カテゴリーが満杯です！新しくカテゴリーを作成して設定してください。")
+        return
+    
+    return target_category

--- a/wathematica_discord_bot/view/settings_view.py
+++ b/wathematica_discord_bot/view/settings_view.py
@@ -1,0 +1,417 @@
+import asyncio
+import discord
+from database import async_session
+from model import Guild, Category, SeminarState
+from sqlalchemy import select
+
+
+async def get_settings_embed(
+    guild_id: int, guild_name: str, bot: discord.Bot
+) -> discord.Embed:
+    async with async_session() as session:
+        stmt_guild = select(Guild).where(Guild.guild_id == guild_id)
+        guild = (await session.execute(stmt_guild)).scalar_one_or_none()
+
+        stmt_cat = select(Category).where(Category.guild_id == guild_id)
+        categories = (await session.execute(stmt_cat)).scalars().all()
+
+    # 基本設定の表示文字列作成
+    role_channel_mention = (
+        f"<#{guild.role_setting_channel_id}>"
+        if guild and guild.role_setting_channel_id
+        else "未設定"
+    )
+
+    system_channel_mention = (
+        f"<#{guild.system_channel_id}>"
+        if guild and hasattr(guild, "system_channel_id") and guild.system_channel_id
+        else "未設定"
+    )
+
+    engineer_role_mention = (
+        f"<@&{guild.engineer_role_id}>"
+        if guild and guild.engineer_role_id
+        else "未設定"
+    )
+
+    emoji_display = "未設定"
+    if guild and guild.interesting_emoji_id:
+        emoji_obj = bot.get_emoji(guild.interesting_emoji_id)
+        emoji_display = (
+            str(emoji_obj)
+            if emoji_obj
+            else f"ID: `{guild.interesting_emoji_id}` (見つかりません)"
+        )
+
+    pending_cats = [
+        f"`{category.name}`"
+        for category in categories
+        if category.state == SeminarState.PENDING
+    ]
+    ongoing_cats = [
+        f"`{category.name}`"
+        for category in categories
+        if category.state == SeminarState.ONGOING
+    ]
+    paused_cats = [
+        f"`{category.name}`"
+        for category in categories
+        if category.state == SeminarState.PAUSED
+    ]
+    finished_cats = [
+        f"`{category.name}`"
+        for category in categories
+        if category.state == SeminarState.FINISHED
+    ]
+
+    embed = discord.Embed(
+        title=":gear: サーバー設定",
+        description="現在の設定状況です。下のボタンから変更を行ってください。",
+        color=discord.Colour.blue(),
+    )
+    # ▼ 追加: システムチャンネルをEmbedに表示
+    embed.add_field(
+        name="現在のシステムチャンネル", value=system_channel_mention, inline=False
+    )
+    embed.add_field(
+        name="現在の権限設定チャンネル", value=role_channel_mention, inline=False
+    )
+    embed.add_field(
+        name="現在の技術部ロール", value=engineer_role_mention, inline=False
+    )
+    embed.add_field(name="現在の興味あり絵文字", value=emoji_display, inline=False)
+
+    embed.add_field(
+        name=":yellow_circle: 仮立て (PENDING)",
+        value=" ".join(pending_cats) or "登録なし",
+        inline=False,
+    )
+    embed.add_field(
+        name=":green_circle: 本運用 (ONGOING)",
+        value=" ".join(ongoing_cats) or "登録なし",
+        inline=False,
+    )
+    embed.add_field(
+        name=":blue_circle: 休止中 (PAUSED)",
+        value=" ".join(paused_cats) or "登録なし",
+        inline=False,
+    )
+    embed.add_field(
+        name=":red_circle: 終了 (FINISHED)",
+        value=" ".join(finished_cats) or "登録なし",
+        inline=False,
+    )
+
+    return embed
+
+
+class CategoryStateSelectView(discord.ui.View):
+    def __init__(
+        self,
+        bot: discord.Bot,
+        dashboard_message: discord.Message,
+        selected_category: discord.abc.GuildChannel,
+    ):
+        super().__init__(timeout=120)
+        self.bot = bot
+        self.dashboard_message = dashboard_message
+        self.selected_category = selected_category
+
+    @discord.ui.select(
+        select_type=discord.ComponentType.string_select,
+        placeholder="このカテゴリーの役割を選択してください...",
+        options=[
+            discord.SelectOption(
+                label="仮立て用", value="PENDING", emoji=":yellow_circle:"
+            ),
+            discord.SelectOption(
+                label="本運用用", value="ONGOING", emoji=":greed_circle:"
+            ),
+            discord.SelectOption(
+                label="休止中用", value="PAUSED", emoji=":blue_circle:"
+            ),
+            discord.SelectOption(
+                label="終了済み用", value="FINISHED", emoji=":red_circle:"
+            ),
+            discord.SelectOption(
+                label="登録を解除する",
+                value="REMOVE",
+                description="Botの管理対象から外します",
+                emoji="🗑️",
+            ),
+        ],
+    )
+    async def select_state(
+        self, select_menu: discord.ui.Select, interaction: discord.Interaction
+    ):
+        state_val = select_menu.values[0]
+        async with async_session() as session:
+            async with session.begin():
+                stmt_guild = select(Guild).where(Guild.guild_id == interaction.guild.id)
+                guild = (await session.execute(stmt_guild)).scalar_one_or_none()
+                if not guild:
+                    guild = Guild(
+                        guild_id=interaction.guild.id, name=interaction.guild.name
+                    )
+                    session.add(guild)
+
+                stmt_cat = select(Category).where(
+                    Category.category_id == self.selected_category.id
+                )
+                category_record = (await session.execute(stmt_cat)).scalar_one_or_none()
+
+                if state_val == "REMOVE":
+                    if category_record:
+                        await session.delete(category_record)
+                        msg = f"🗑️ カテゴリー {self.selected_category.mention} の登録を解除しました。"
+                    else:
+                        msg = ":warning: そのカテゴリーは元々登録されていません。"
+                else:
+                    state_enum = getattr(SeminarState, state_val)
+                    if category_record:
+                        category_record.state = state_enum
+                    else:
+                        category_record = Category(
+                            category_id=self.selected_category.id,
+                            name=self.selected_category.name,
+                            guild_id=interaction.guild.id,
+                            state=state_enum,
+                            category_type="regular",
+                        )
+                        session.add(category_record)
+                    msg = f":white_check_mark: カテゴリー {self.selected_category.mention} を `{state_val}` として登録しました！"
+
+        new_embed = await get_settings_embed(
+            interaction.guild.id, interaction.guild.name, self.bot
+        )
+        await self.dashboard_message.edit(embed=new_embed)
+        await interaction.response.edit_message(content=msg, view=None)
+
+
+class CategorySelectView(discord.ui.View):
+    def __init__(self, bot: discord.Bot, dashboard_message: discord.Message):
+        super().__init__(timeout=120)
+        self.bot = bot
+        self.dashboard_message = dashboard_message
+
+    @discord.ui.select(
+        select_type=discord.ComponentType.channel_select,
+        placeholder="設定したいカテゴリーを選択...",
+        channel_types=[discord.ChannelType.category],
+    )
+    async def select_category(
+        self, select_menu: discord.ui.Select, interaction: discord.Interaction
+    ):
+        selected_category = select_menu.values[0]
+        next_view = CategoryStateSelectView(
+            self.bot, self.dashboard_message, selected_category
+        )
+        await interaction.response.edit_message(
+            content=f"次に、カテゴリー {selected_category.mention} の役割を選択してください：",
+            view=next_view,
+        )
+
+
+class ChannelSelectView(discord.ui.View):
+    # setting_type 引数を追加して、どちらの設定か判別できるようにする
+    def __init__(
+        self, bot: discord.Bot, dashboard_message: discord.Message, setting_type: str
+    ):
+        super().__init__(timeout=120)
+        self.bot = bot
+        self.dashboard_message = dashboard_message
+        self.setting_type = setting_type
+
+    @discord.ui.select(
+        select_type=discord.ComponentType.channel_select,
+        placeholder="新しいチャンネルを選択...",
+        channel_types=[discord.ChannelType.text],
+    )
+    async def select_callback(
+        self, select_menu: discord.ui.Select, interaction: discord.Interaction
+    ):
+        selected_channel = select_menu.values[0]
+        async with async_session() as session:
+            async with session.begin():
+                stmt = select(Guild).where(Guild.guild_id == interaction.guild.id)
+                guild = (await session.execute(stmt)).scalar_one_or_none()
+                if not guild:
+                    guild = Guild(
+                        guild_id=interaction.guild.id, name=interaction.guild.name
+                    )
+                    session.add(guild)
+
+                # setting_type に応じて保存先カラムを変える
+                if self.setting_type == "role":
+                    guild.role_setting_channel_id = selected_channel.id
+                    target_name = "権限設定チャンネル"
+                elif self.setting_type == "system":
+                    guild.system_channel_id = selected_channel.id
+                    target_name = "システムチャンネル"
+
+        new_embed = await get_settings_embed(
+            interaction.guild.id, interaction.guild.name, self.bot
+        )
+        await self.dashboard_message.edit(embed=new_embed)
+        await interaction.response.send_message(
+            f":white_check_mark: {target_name}を {selected_channel.mention} に変更しました！",
+            ephemeral=True,
+        )
+        self.stop()
+
+
+class RoleSelectView(discord.ui.View):
+    def __init__(self, bot: discord.Bot, dashboard_message: discord.Message):
+        super().__init__(timeout=120)
+        self.bot = bot
+        self.dashboard_message = dashboard_message
+
+    @discord.ui.select(
+        select_type=discord.ComponentType.role_select,
+        placeholder="技術部ロールを選択...",
+    )
+    async def select_callback(
+        self, select_menu: discord.ui.Select, interaction: discord.Interaction
+    ):
+        selected_role = select_menu.values[0]
+        async with async_session() as session:
+            async with session.begin():
+                stmt = select(Guild).where(Guild.guild_id == interaction.guild.id)
+                guild = (await session.execute(stmt)).scalar_one_or_none()
+                if not guild:
+                    guild = Guild(
+                        guild_id=interaction.guild.id, name=interaction.guild.name
+                    )
+                    session.add(guild)
+                guild.engineer_role_id = selected_role.id
+
+        new_embed = await get_settings_embed(
+            interaction.guild.id, interaction.guild.name, self.bot
+        )
+        await self.dashboard_message.edit(embed=new_embed)
+        await interaction.response.send_message(
+            f":white_check_mark: 技術部ロールを {selected_role.mention} に設定しました！",
+            ephemeral=True,
+        )
+        self.stop()
+
+
+class SettingsDashboardView(discord.ui.View):
+    def __init__(self, bot: discord.Bot):
+        super().__init__(timeout=180.0)
+        self.bot = bot
+        self.message: discord.Message | None = None
+
+    @discord.ui.button(
+        label="システムCHの変更", style=discord.ButtonStyle.secondary, row=0
+    )
+    async def change_system_channel(
+        self, button: discord.ui.Button, interaction: discord.Interaction
+    ):
+        view = ChannelSelectView(self.bot, interaction.message, setting_type="system")
+        await interaction.response.send_message(
+            "変更先のシステムチャンネルを選択してください：", view=view, ephemeral=True
+        )
+
+    @discord.ui.button(
+        label="権限設定CHの変更", style=discord.ButtonStyle.secondary, row=0
+    )
+    async def change_role_channel(
+        self, button: discord.ui.Button, interaction: discord.Interaction
+    ):
+        view = ChannelSelectView(self.bot, interaction.message, setting_type="role")
+        await interaction.response.send_message(
+            "変更先の権限設定チャンネルを選択してください：", view=view, ephemeral=True
+        )
+
+    @discord.ui.button(
+        label="技術部ロールの変更", style=discord.ButtonStyle.danger, row=0
+    )
+    async def change_engineer_role(
+        self, button: discord.ui.Button, interaction: discord.Interaction
+    ):
+        view = RoleSelectView(self.bot, interaction.message)
+        await interaction.response.send_message(
+            "このBotを管理する「技術部」のロールを選択してください：",
+            view=view,
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="カテゴリーの設定", style=discord.ButtonStyle.primary, row=1
+    )
+    async def change_category(
+        self, button: discord.ui.Button, interaction: discord.Interaction
+    ):
+        view = CategorySelectView(self.bot, interaction.message)
+        await interaction.response.send_message(
+            "設定を変更・登録したいカテゴリーを選択してください：",
+            view=view,
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="興味あり絵文字の変更", style=discord.ButtonStyle.secondary, row=1
+    )
+    async def change_emoji(
+        self, button: discord.ui.Button, interaction: discord.Interaction
+    ):
+        await interaction.response.defer(ephemeral=True)
+        prompt_msg = await interaction.channel.send(
+            f"{interaction.user.mention} このメッセージに「興味あり」として設定したいスタンプでリアクションしてください！（60秒以内にご対応ください）"
+        )
+
+        def check(reaction, user):
+            return user == interaction.user and reaction.message.id == prompt_msg.id
+
+        try:
+            reaction, user = await self.bot.wait_for(
+                "reaction_add", timeout=60.0, check=check
+            )
+        except asyncio.TimeoutError:
+            await prompt_msg.edit(
+                content=":warning: タイムアウトしました。もう一度やり直してください。"
+            )
+            return
+
+        emoji_id = None
+        if hasattr(reaction.emoji, "id") and reaction.emoji.id:
+            emoji_id = reaction.emoji.id
+
+        if not emoji_id:
+            await prompt_msg.edit(
+                content=":x: カスタム絵文字（サーバー独自の絵文字）のみ登録可能です。標準絵文字は使えません。"
+            )
+            return
+
+        async with async_session() as session:
+            async with session.begin():
+                stmt = select(Guild).where(Guild.guild_id == interaction.guild.id)
+                guild = (await session.execute(stmt)).scalar_one_or_none()
+                if not guild:
+                    guild = Guild(
+                        guild_id=interaction.guild.id, name=interaction.guild.name
+                    )
+                    session.add(guild)
+                guild.interesting_emoji_id = emoji_id
+
+        await prompt_msg.delete()
+        new_embed = await get_settings_embed(
+            interaction.guild.id, interaction.guild.name, self.bot
+        )
+        await interaction.message.edit(embed=new_embed)
+        await interaction.followup.send(
+            ":white_check_mark: 絵文字を更新しました！", ephemeral=True
+        )
+
+    async def on_timeout(self):
+        for child in self.children:
+            child.disabled = True
+        if self.message:
+            try:
+                embed = self.message.embeds[0]
+                embed.title = ":gear: サーバー設定 [操作期限切れ]"
+                embed.color = discord.Colour.light_grey()
+                await self.message.edit(embed=embed, view=self)
+            except discord.HTTPException:
+                pass

--- a/wathematica_discord_bot/view/settings_view.py
+++ b/wathematica_discord_bot/view/settings_view.py
@@ -162,7 +162,7 @@ class CategoryStateSelectView(discord.ui.View):
                 if state_val == "REMOVE":
                     if category_record:
                         await session.delete(category_record)
-                        msg = f"🗑️ カテゴリー {self.selected_category.mention} の登録を解除しました。"
+                        msg = f"🗑️ カテゴリー《{self.selected_category.name}》の登録を解除しました。"
                     else:
                         msg = ":warning: そのカテゴリーは元々登録されていません。"
                 else:
@@ -178,7 +178,7 @@ class CategoryStateSelectView(discord.ui.View):
                             category_type="regular",
                         )
                         session.add(category_record)
-                    msg = f":white_check_mark: カテゴリー {self.selected_category.mention} を `{state_val}` として登録しました！"
+                    msg = f":white_check_mark: カテゴリー《{self.selected_category.name}》 を `{state_val}` として登録しました！"
 
         new_embed = await get_settings_embed(
             interaction.guild.id, interaction.guild.name, self.bot
@@ -206,7 +206,7 @@ class CategorySelectView(discord.ui.View):
             self.bot, self.dashboard_message, selected_category
         )
         await interaction.response.edit_message(
-            content=f"次に、カテゴリー {selected_category.mention} の役割を選択してください：",
+            content=f"次に、カテゴリー《{selected_category.name}》の役割を選択してください：",
             view=next_view,
         )
 

--- a/wathematica_discord_bot/view/settings_view.py
+++ b/wathematica_discord_bot/view/settings_view.py
@@ -122,22 +122,21 @@ class CategoryStateSelectView(discord.ui.View):
         placeholder="このカテゴリーの役割を選択してください...",
         options=[
             discord.SelectOption(
-                label="仮立て用", value="PENDING", emoji=":yellow_circle:"
+                label="仮立て用", value="PENDING",
             ),
             discord.SelectOption(
-                label="本運用用", value="ONGOING", emoji=":greed_circle:"
+                label="本運用用", value="ONGOING",
             ),
             discord.SelectOption(
-                label="休止中用", value="PAUSED", emoji=":blue_circle:"
+                label="休止中用", value="PAUSED",
             ),
             discord.SelectOption(
-                label="終了済み用", value="FINISHED", emoji=":red_circle:"
+                label="終了済み用", value="FINISHED",
             ),
             discord.SelectOption(
                 label="登録を解除する",
                 value="REMOVE",
                 description="Botの管理対象から外します",
-                emoji="🗑️",
             ),
         ],
     )


### PR DESCRIPTION
※ 大きめの変更です

## やったこと
- 今まで config ファイルで管理していたサーバー情報を DB で管理するようにした
  - category`, `guild` というテーブルを作成してそこで保存する
- それに伴い、各 Cogs でのサーバー情報取得部分を変更した
- サーバー情報設定用のコマンドを追加した

## できるようになったこと
- サーバーへの導入時に自動でカテゴリー情報・チャンネル情報・スタンプ情報を取得して DB に登録できる（`auto_setup.py`）
- 手動で上記のような設定を編集できる（`settings.py`）
  - みやすいダッシュボードの作成（`/settings` コマンドを利用）<img width="633" height="649" alt="image" src="https://github.com/user-attachments/assets/53345ee4-a46f-41b4-b180-4c4cf06ae163" />

## TODO
- [ ] ロール指定、カテゴリー指定に関する制限を行う（`checks.py` への追記とデコレータの利用）
- [ ] 初期設定が行われていない場合のエラーハンドリング

## やらないこと
- `/new` コマンドを利用できるチャンネルの制限（別 PR で対応、実装準備は OK）
- エラーメッセージを技術部チャンネルに通知（別 PR で対応、未検討）